### PR TITLE
Add opt-in PKCS12 and JKS keystore provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.28.0
 	github.com/onsi/gomega v1.39.1
+	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spiffe/go-spiffe/v2 v2.6.0
@@ -20,9 +21,9 @@ require (
 	k8s.io/client-go v0.35.2
 	k8s.io/component-base v0.35.2
 	k8s.io/klog/v2 v2.140.0
-	k8s.io/mount-utils v0.34.3
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.23.1
+	software.sslmate.com/src/go-pkcs12 v0.7.0
 )
 
 require (
@@ -99,6 +100,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20260127142750-a19766b6e2d4 // indirect
+	k8s.io/mount-utils v0.34.3 // indirect
 	sigs.k8s.io/gateway-api v1.5.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/onsi/ginkgo/v2 v2.28.0 h1:Rrf+lVLmtlBIKv6KrIGJCjyY8N36vDVcutbGJkyqjJc
 github.com/onsi/ginkgo/v2 v2.28.0/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 h1:2nosf3P75OZv2/ZO/9Px5ZgZ5gbKrzA3joN1QMfOGMQ=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0/go.mod h1:lAVhWwbNaveeJmxrxuSTxMgKpF6DjnuVpn6T8WiBwYQ=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -300,3 +302,5 @@ sigs.k8s.io/structured-merge-diff/v6 v6.3.2 h1:kwVWMx5yS1CrnFWA/2QHyRVJ8jM6dBA80
 sigs.k8s.io/structured-merge-diff/v6 v6.3.2/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
+software.sslmate.com/src/go-pkcs12 v0.7.0 h1:Db8W44cB54TWD7stUFFSWxdfpdn6fZVcDl0w3R4RVM0=
+software.sslmate.com/src/go-pkcs12 v0.7.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -87,6 +87,11 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				CertificateFileName: opts.Volume.CertificateFileName,
 				KeyFileName:         opts.Volume.KeyFileName,
 				CAFileName:          opts.Volume.CAFileName,
+				KeystoreEnabled:     opts.Volume.KeystoreEnabled,
+				KeystoreFileName:    opts.Volume.KeystoreFileName,
+				JKSFileName:         opts.Volume.JKSFileName,
+				KeystorePassword:    opts.Volume.KeystorePassword,
+				KeystoreAlias:       opts.Volume.KeystoreAlias,
 
 				RootCAs: rootCA,
 

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -17,6 +17,9 @@ limitations under the License.
 package options
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -26,6 +29,10 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
+
+// DefaultKeystorePassword is the well-known Java keystore default used when
+// --keystore-password-file is not configured.
+const DefaultKeystorePassword = "changeit"
 
 // Options are the CSI Driver flag options.
 type Options struct {
@@ -108,8 +115,15 @@ type OptionsVolume struct {
 	// Pod's volume. Has no effect unless KeystoreEnabled is true.
 	JKSFileName string
 
+	// KeystorePasswordFile is a file path whose contents are used as the
+	// password to encrypt the PKCS12 / JKS keystores. When empty, the
+	// well-known Java default `changeit` is used. The password is intentionally
+	// not exposed as a plain CLI flag to avoid leaking it via `ps`.
+	KeystorePasswordFile string
+
 	// KeystorePassword is the password used to encrypt the PKCS12 / JKS
-	// keystores.
+	// keystores. Populated from KeystorePasswordFile (or the built-in default)
+	// during option completion; not set directly by a flag.
 	KeystorePassword string
 
 	// KeystoreAlias is the alias used for the private key entry inside the
@@ -211,8 +225,11 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 		"The file name of the JKS keystore written into the pod's volume. "+
 			"Requires --enable-keystore. Set to an empty string to skip JKS "+
 			"keystore generation while still writing the PKCS12 keystore.")
-	fs.StringVar(&o.Volume.KeystorePassword, "keystore-password", "changeit",
-		"Password used to encrypt the PKCS12 and JKS keystores. "+
+	fs.StringVar(&o.Volume.KeystorePasswordFile, "keystore-password-file", "",
+		"File path whose contents are used as the password to encrypt the "+
+			"PKCS12 and JKS keystores. When unset, the well-known Java default "+
+			"`changeit` is used. The password is read from a file rather than "+
+			"taken as a CLI flag to avoid exposing it via `ps`. "+
 			"Requires --enable-keystore.")
 	fs.StringVar(&o.Volume.KeystoreAlias, "keystore-alias", "service",
 		"Alias used for the private key entry inside the JKS keystore. "+
@@ -228,4 +245,40 @@ func (o *Options) addAthenzFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Athenz.CertOrgName, "cert-org-name", "Athenz", "Organization name in the service identity certificate.")
 	fs.StringVar(&o.Athenz.CloudProvider, "cloud-provider", "", "Cloud provider where the driver is running.")
 	fs.StringVar(&o.Athenz.CloudRegion, "cloud-region", "", "Cloud region where the driver is running.")
+}
+
+// Complete extends the embedded Flags.Complete with options-specific
+// finalisation, in particular reading the keystore password from disk so it
+// is not exposed via process arguments.
+func (o *Options) Complete() error {
+	if err := o.Flags.Complete(); err != nil {
+		return err
+	}
+	return o.loadKeystorePassword()
+}
+
+// loadKeystorePassword populates Volume.KeystorePassword from
+// KeystorePasswordFile when set, falling back to DefaultKeystorePassword
+// otherwise. Trailing whitespace (typically a trailing newline from
+// `echo "..." > file`) is stripped.
+func (o *Options) loadKeystorePassword() error {
+	if !o.Volume.KeystoreEnabled {
+		return nil
+	}
+	if o.Volume.KeystorePasswordFile == "" {
+		o.Volume.KeystorePassword = DefaultKeystorePassword
+		return nil
+	}
+	data, err := os.ReadFile(o.Volume.KeystorePasswordFile)
+	if err != nil {
+		return fmt.Errorf("reading --keystore-password-file %q: %w",
+			o.Volume.KeystorePasswordFile, err)
+	}
+	password := strings.TrimRight(string(data), "\r\n")
+	if password == "" {
+		return fmt.Errorf("--keystore-password-file %q is empty",
+			o.Volume.KeystorePasswordFile)
+	}
+	o.Volume.KeystorePassword = password
+	return nil
 }

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -94,6 +94,27 @@ type OptionsVolume struct {
 	// encoded X.509 root CA certificates that will be written to managed volumes
 	// at the CSICAFileName path. No CAs will be written if this is empty.
 	SourceCABundleFile string
+
+	// KeystoreEnabled is the master switch for PKCS12 / JKS keystore
+	// provisioning. Disabled by default; opt in to write PKCS12 / JKS files
+	// alongside the PEM identity files.
+	KeystoreEnabled bool
+
+	// KeystoreFileName is the file name used for the PKCS12 keystore written
+	// into the Pod's volume. Has no effect unless KeystoreEnabled is true.
+	KeystoreFileName string
+
+	// JKSFileName is the file name used for the JKS keystore written into the
+	// Pod's volume. Has no effect unless KeystoreEnabled is true.
+	JKSFileName string
+
+	// KeystorePassword is the password used to encrypt the PKCS12 / JKS
+	// keystores.
+	KeystorePassword string
+
+	// KeystoreAlias is the alias used for the private key entry inside the
+	// JKS keystore.
+	KeystoreAlias string
 }
 
 // OptionsAthenz is options specific to Athenz.
@@ -173,6 +194,29 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 		"File path that is read by the driver which will be written to all managed "+
 			"volumes to the file location inside volumes defined in --file-name-ca. If "+
 			"undefined, no CA file is written to volumes.")
+
+	fs.BoolVar(&o.Volume.KeystoreEnabled, "enable-keystore", false,
+		"Enable provisioning of PKCS12 and JKS keystores alongside the PEM "+
+			"identity files. When false (default), no keystores are written and "+
+			"the --file-name-keystore / --file-name-jks / --keystore-password / "+
+			"--keystore-alias flags have no effect.")
+	fs.StringVar(&o.Volume.KeystoreFileName, "file-name-keystore", "service.pkcs12",
+		"The file name of the PKCS12 keystore written into the pod's volume. "+
+			"Requires --enable-keystore. The keystore contains the private key "+
+			"and leaf certificate using the legacy PKCS12 encoding to mirror the "+
+			"on-disk format produced by `openssl pkcs12 -export -noiter -nomaciter`. "+
+			"Set to an empty string to skip PKCS12 keystore generation while still "+
+			"writing the JKS keystore.")
+	fs.StringVar(&o.Volume.JKSFileName, "file-name-jks", "service.jks",
+		"The file name of the JKS keystore written into the pod's volume. "+
+			"Requires --enable-keystore. Set to an empty string to skip JKS "+
+			"keystore generation while still writing the PKCS12 keystore.")
+	fs.StringVar(&o.Volume.KeystorePassword, "keystore-password", "changeit",
+		"Password used to encrypt the PKCS12 and JKS keystores. "+
+			"Requires --enable-keystore.")
+	fs.StringVar(&o.Volume.KeystoreAlias, "keystore-alias", "service",
+		"Alias used for the private key entry inside the JKS keystore. "+
+			"Requires --enable-keystore.")
 }
 
 func (o *Options) addAthenzFlags(fs *pflag.FlagSet) {

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -31,8 +31,14 @@ import (
 )
 
 // DefaultKeystorePassword is the well-known Java keystore default used when
-// --keystore-password-file is not configured.
+// neither KeystorePasswordEnvVar nor --keystore-password-file is configured.
 const DefaultKeystorePassword = "changeit"
+
+// KeystorePasswordEnvVar is the environment variable read at startup for the
+// keystore password. When set, it takes precedence over
+// --keystore-password-file. Intentionally not exposed as a CLI flag to avoid
+// leaking the password via `ps`.
+const KeystorePasswordEnvVar = "KEYSTORE_PASSWORD"
 
 // Options are the CSI Driver flag options.
 type Options struct {
@@ -116,14 +122,18 @@ type OptionsVolume struct {
 	JKSFileName string
 
 	// KeystorePasswordFile is a file path whose contents are used as the
-	// password to encrypt the PKCS12 / JKS keystores. When empty, the
-	// well-known Java default `changeit` is used. The password is intentionally
-	// not exposed as a plain CLI flag to avoid leaking it via `ps`.
+	// password to encrypt the PKCS12 / JKS keystores. Ignored if the
+	// KeystorePasswordEnvVar environment variable is set; otherwise, when
+	// empty, the well-known Java default `changeit` is used. The password is
+	// intentionally not exposed as a plain CLI flag to avoid leaking it
+	// via `ps`.
 	KeystorePasswordFile string
 
 	// KeystorePassword is the password used to encrypt the PKCS12 / JKS
-	// keystores. Populated from KeystorePasswordFile (or the built-in default)
-	// during option completion; not set directly by a flag.
+	// keystores. Resolved during option completion from (in order of
+	// precedence) the KeystorePasswordEnvVar environment variable, the
+	// KeystorePasswordFile contents, or the built-in default. Not set
+	// directly by a flag.
 	KeystorePassword string
 
 	// KeystoreAlias is the alias used for the private key entry inside the
@@ -227,9 +237,10 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 			"keystore generation while still writing the PKCS12 keystore.")
 	fs.StringVar(&o.Volume.KeystorePasswordFile, "keystore-password-file", "",
 		"File path whose contents are used as the password to encrypt the "+
-			"PKCS12 and JKS keystores. When unset, the well-known Java default "+
-			"`changeit` is used. The password is read from a file rather than "+
-			"taken as a CLI flag to avoid exposing it via `ps`. "+
+			"PKCS12 and JKS keystores. Ignored when the KEYSTORE_PASSWORD "+
+			"environment variable is set (env wins). When both are unset, the "+
+			"well-known Java default `changeit` is used. The password is "+
+			"never accepted as a plain CLI flag, to avoid exposing it via `ps`. "+
 			"Requires --enable-keystore.")
 	fs.StringVar(&o.Volume.KeystoreAlias, "keystore-alias", "service",
 		"Alias used for the private key entry inside the JKS keystore. "+
@@ -257,18 +268,31 @@ func (o *Options) Complete() error {
 	return o.loadKeystorePassword()
 }
 
-// loadKeystorePassword populates Volume.KeystorePassword from
-// KeystorePasswordFile when set, falling back to DefaultKeystorePassword
-// otherwise. Trailing whitespace (typically a trailing newline from
-// `echo "..." > file`) is stripped.
+// loadKeystorePassword resolves Volume.KeystorePassword using the following
+// precedence (highest to lowest):
+//
+//  1. KeystorePasswordEnvVar environment variable, if non-empty
+//  2. KeystorePasswordFile contents (trailing CR/LF stripped), if the flag is set
+//  3. DefaultKeystorePassword built-in fallback (`changeit`)
+//
+// An explicitly-set but empty file is treated as a startup error so a
+// misconfigured Secret mount fails fast rather than silently using a blank
+// password.
 func (o *Options) loadKeystorePassword() error {
 	if !o.Volume.KeystoreEnabled {
 		return nil
 	}
+
+	if envPassword, ok := os.LookupEnv(KeystorePasswordEnvVar); ok && envPassword != "" {
+		o.Volume.KeystorePassword = envPassword
+		return nil
+	}
+
 	if o.Volume.KeystorePasswordFile == "" {
 		o.Volume.KeystorePassword = DefaultKeystorePassword
 		return nil
 	}
+
 	data, err := os.ReadFile(o.Volume.KeystorePasswordFile)
 	if err != nil {
 		return fmt.Errorf("reading --keystore-password-file %q: %w",

--- a/internal/csi/app/options/options_test.go
+++ b/internal/csi/app/options/options_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright The Athenz Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Test_loadKeystorePassword_Precedence covers the resolution order:
+//   1. KEYSTORE_PASSWORD env var (when non-empty)
+//   2. --keystore-password-file contents
+//   3. built-in default "changeit"
+//
+// It also covers the disabled-feature short-circuit and the empty-file
+// fail-fast behaviour.
+func Test_loadKeystorePassword_Precedence(t *testing.T) {
+	writeFile := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "password")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0600))
+		return path
+	}
+
+	t.Run("disabled-skips-resolution", func(t *testing.T) {
+		t.Setenv(KeystorePasswordEnvVar, "from-env")
+		o := &Options{}
+		o.Volume.KeystoreEnabled = false
+		o.Volume.KeystorePasswordFile = writeFile(t, "from-file")
+		require.NoError(t, o.loadKeystorePassword())
+		require.Empty(t, o.Volume.KeystorePassword,
+			"disabled feature must not populate KeystorePassword from any source")
+	})
+
+	t.Run("env-wins-over-file", func(t *testing.T) {
+		t.Setenv(KeystorePasswordEnvVar, "from-env")
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		o.Volume.KeystorePasswordFile = writeFile(t, "from-file")
+		require.NoError(t, o.loadKeystorePassword())
+		require.Equal(t, "from-env", o.Volume.KeystorePassword)
+	})
+
+	t.Run("file-when-env-unset", func(t *testing.T) {
+		// Setenv with "" and then unsetting would still differ from "unset";
+		// rely on a fresh process env: parent test does not set the var.
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		o.Volume.KeystorePasswordFile = writeFile(t, "from-file\n")
+		require.NoError(t, o.loadKeystorePassword())
+		require.Equal(t, "from-file", o.Volume.KeystorePassword,
+			"trailing newline from `echo > file` must be stripped")
+	})
+
+	t.Run("env-empty-falls-through-to-file", func(t *testing.T) {
+		t.Setenv(KeystorePasswordEnvVar, "")
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		o.Volume.KeystorePasswordFile = writeFile(t, "from-file")
+		require.NoError(t, o.loadKeystorePassword())
+		require.Equal(t, "from-file", o.Volume.KeystorePassword,
+			"an env var set to the empty string must be treated as unset")
+	})
+
+	t.Run("default-when-nothing-set", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		require.NoError(t, o.loadKeystorePassword())
+		require.Equal(t, DefaultKeystorePassword, o.Volume.KeystorePassword)
+	})
+
+	t.Run("explicit-empty-file-is-fatal", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		o.Volume.KeystorePasswordFile = writeFile(t, "")
+		err := o.loadKeystorePassword()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is empty")
+	})
+
+	t.Run("missing-file-is-fatal", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.KeystoreEnabled = true
+		o.Volume.KeystorePasswordFile = filepath.Join(t.TempDir(), "does-not-exist")
+		err := o.loadKeystorePassword()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reading --keystore-password-file")
+	})
+}

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -607,7 +607,11 @@ func encodePKCS12(key crypto.PrivateKey, leaf *x509.Certificate, password string
 func encodeJKS(privateKeyDER []byte, leaf *x509.Certificate, alias, password string) ([]byte, error) {
 	ks := keystore.New()
 	if err := ks.SetPrivateKeyEntry(alias, keystore.PrivateKeyEntry{
-		CreationTime: time.Now(),
+		// Use the leaf's NotBefore (not time.Now()) so the encoded JKS bytes
+		// are a pure function of the certificate. This keeps the on-disk file
+		// stable for a given cert and avoids needlessly tripping file
+		// watchers when writeKeypair runs without the cert actually changing.
+		CreationTime: leaf.NotBefore,
 		PrivateKey:   privateKeyDER,
 		CertificateChain: []keystore.Certificate{
 			{Type: "X509", Content: leaf.Raw},

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -558,9 +558,16 @@ func (d *Driver) writeKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 		if err != nil {
 			return fmt.Errorf("parsing certificate chain for keystore: %w", err)
 		}
-		leaf := pickLeaf(chainCerts)
+		leaf, fellBack := pickLeaf(chainCerts)
 		if leaf == nil {
 			return fmt.Errorf("no certificates found in chain for keystore")
+		}
+		if fellBack {
+			d.log.Info("no non-CA certificate found in chain; falling back to the first cert for keystore",
+				"chainLength", len(chainCerts),
+				"leafSubject", leaf.Subject.String(),
+				"leafIsCA", leaf.IsCA,
+			)
 		}
 
 		if len(d.keystoreFileName) > 0 {
@@ -630,18 +637,19 @@ func encodeJKS(privateKeyDER []byte, leaf *x509.Certificate, alias, password str
 // pickLeaf returns the first non-CA certificate from certs (i.e. the end-entity
 // leaf), regardless of position in the chain. As a safety net for chains where
 // no certificate has IsCA=false (which would be unusual for an issued service
-// identity), it falls back to the first certificate. Returns nil if certs is
+// identity), it falls back to the first certificate and reports fellBack=true
+// so the caller can surface the anomaly. Returns (nil, false) if certs is
 // empty.
-func pickLeaf(certs []*x509.Certificate) *x509.Certificate {
+func pickLeaf(certs []*x509.Certificate) (leaf *x509.Certificate, fellBack bool) {
 	for _, c := range certs {
 		if !c.IsCA {
-			return c
+			return c, false
 		}
 	}
 	if len(certs) > 0 {
-		return certs[0]
+		return certs[0], true
 	}
-	return nil
+	return nil, false
 }
 
 // parseCertChain decodes all CERTIFICATE PEM blocks in data into x509

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	"crypto/x509"
@@ -37,12 +38,23 @@ import (
 	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/cert-manager/csi-lib/storage"
 	"github.com/go-logr/logr"
+	keystore "github.com/pavlo-v-chernykh/keystore-go/v4"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/clock"
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
 
 	"github.com/AthenZ/csi-driver-athenz/internal/csi/rootca"
 )
+
+// DefaultKeystorePassword is the password used to encrypt the PKCS12 / JKS
+// keystores when none is configured. Matches the conventional Java keystore
+// default.
+const DefaultKeystorePassword = "changeit"
+
+// DefaultKeystoreAlias is the alias used for the private key entry inside the
+// generated JKS keystore.
+const DefaultKeystoreAlias = "service"
 
 const (
 	cloudMetaEndpoint      = "http://169.254.169.254:80"
@@ -97,6 +109,32 @@ type Options struct {
 	// CAFileName is the name of the file that the root CA certificates will be
 	// written to inside the Pod's volume. Ignored if RootCAs is nil.
 	CAFileName string
+
+	// KeystoreEnabled is the master switch for PKCS12 / JKS keystore
+	// provisioning. When false (the default), no keystores are written and
+	// the keystore-related options below are ignored.
+	KeystoreEnabled bool
+
+	// KeystoreFileName is the name of the PKCS12 keystore file written into the
+	// Pod's volume. The keystore contains the private key and leaf certificate,
+	// using the legacy PKCS12 encoding. Has no effect unless KeystoreEnabled
+	// is true. If empty when KeystoreEnabled is true, no PKCS12 keystore is
+	// written.
+	KeystoreFileName string
+
+	// JKSFileName is the name of the JKS keystore file written into the Pod's
+	// volume. The keystore contains the private key and leaf certificate. Has
+	// no effect unless KeystoreEnabled is true. If empty when KeystoreEnabled
+	// is true, no JKS keystore is written.
+	JKSFileName string
+
+	// KeystorePassword is the password used to encrypt both the PKCS12 and JKS
+	// keystores. Defaults to DefaultKeystorePassword if empty.
+	KeystorePassword string
+
+	// KeystoreAlias is the alias used for the private key entry inside the
+	// JKS keystore. Defaults to DefaultKeystoreAlias if empty.
+	KeystoreAlias string
 
 	// RestConfig is used for interacting with the Kubernetes API server.
 	RestConfig *rest.Config
@@ -157,6 +195,28 @@ type Driver struct {
 	// to volumes.
 	certFileName, keyFileName, caFileName string
 
+	// keystoreEnabled gates PKCS12 / JKS provisioning entirely. When false,
+	// keystoreFileName and jksFileName are ignored.
+	keystoreEnabled bool
+
+	// keystoreFileName is the file name of the PKCS12 keystore written to
+	// volumes. Ignored when keystoreEnabled is false; if empty when enabled,
+	// no PKCS12 keystore is written.
+	keystoreFileName string
+
+	// jksFileName is the file name of the JKS keystore written to volumes.
+	// Ignored when keystoreEnabled is false; if empty when enabled, no JKS
+	// keystore is written.
+	jksFileName string
+
+	// keystorePassword is the password used to encrypt the PKCS12 / JKS
+	// keystores.
+	keystorePassword string
+
+	// keystoreAlias is the alias used for the private key entry inside the
+	// JKS keystore.
+	keystoreAlias string
+
 	// rootCAs provides the root CA certificates to write to file. No CA file is
 	// written if this is nil.
 	rootCAs rootca.Interface
@@ -206,6 +266,11 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		certFileName:               opts.CertificateFileName,
 		keyFileName:                opts.KeyFileName,
 		caFileName:                 opts.CAFileName,
+		keystoreEnabled:            opts.KeystoreEnabled,
+		keystoreFileName:           opts.KeystoreFileName,
+		jksFileName:                opts.JKSFileName,
+		keystorePassword:           opts.KeystorePassword,
+		keystoreAlias:              opts.KeystoreAlias,
 		issuerRef:                  opts.IssuerRef,
 		rootCAs:                    opts.RootCAs,
 		certificateRequestDuration: opts.CertificateRequestDuration,
@@ -232,6 +297,12 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 	if d.certificateRequestDuration == 0 {
 		d.certificateRequestDuration = time.Hour
 	}
+	if d.keystoreEnabled && len(d.keystorePassword) == 0 {
+		d.keystorePassword = DefaultKeystorePassword
+	}
+	if len(d.keystoreAlias) == 0 {
+		d.keystoreAlias = DefaultKeystoreAlias
+	}
 
 	var err error
 	store, err := storage.NewFilesystem(d.log, opts.DataRoot)
@@ -244,7 +315,7 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 
 	d.store = store
 	d.camanager = newCAManager(log, store, opts.RootCAs,
-		opts.CertificateFileName, opts.KeyFileName, opts.CAFileName)
+		d.certFileName, d.keyFileName, d.caFileName)
 
 	cmclient, err := cmclient.NewForConfig(opts.RestConfig)
 	if err != nil {
@@ -482,6 +553,33 @@ func (d *Driver) writeKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 		data[d.caFileName] = d.rootCAs.CertificatesPEM()
 	}
 
+	if d.keystoreEnabled && (len(d.keystoreFileName) > 0 || len(d.jksFileName) > 0) {
+		chainCerts, err := parseCertChain(chain)
+		if err != nil {
+			return fmt.Errorf("parsing certificate chain for keystore: %w", err)
+		}
+		leaf := pickLeaf(chainCerts)
+		if leaf == nil {
+			return fmt.Errorf("no certificates found in chain for keystore")
+		}
+
+		if len(d.keystoreFileName) > 0 {
+			p12, err := encodePKCS12(key, leaf, d.keystorePassword)
+			if err != nil {
+				return fmt.Errorf("failed to encode PKCS12 keystore: %w", err)
+			}
+			data[d.keystoreFileName] = p12
+		}
+
+		if len(d.jksFileName) > 0 {
+			jks, err := encodeJKS(pemBytes, leaf, d.keystoreAlias, d.keystorePassword)
+			if err != nil {
+				return fmt.Errorf("failed to encode JKS keystore: %w", err)
+			}
+			data[d.jksFileName] = jks
+		}
+	}
+
 	// Write data to the actual volume that gets mounted.
 	if err := d.store.WriteFiles(meta, data); err != nil {
 		return fmt.Errorf("writing data: %w", err)
@@ -493,4 +591,74 @@ func (d *Driver) writeKeypair(meta metadata.Metadata, key crypto.PrivateKey, cha
 	}
 
 	return nil
+}
+
+// encodePKCS12 builds a PKCS12 keystore containing the private key and leaf
+// certificate, matching the legacy Athenz SIA behaviour produced by
+// `openssl pkcs12 -export -noiter -nomaciter`. CA / intermediate certificates
+// are intentionally omitted to mirror the legacy on-disk format.
+func encodePKCS12(key crypto.PrivateKey, leaf *x509.Certificate, password string) ([]byte, error) {
+	return pkcs12.LegacyRC2.Encode(key, leaf, nil, password)
+}
+
+// encodeJKS builds a JKS keystore containing the private key and leaf
+// certificate, mirroring the legacy Athenz SIA behaviour produced by
+// `keytool -importkeystore` from a PKCS12 source.
+func encodeJKS(privateKeyDER []byte, leaf *x509.Certificate, alias, password string) ([]byte, error) {
+	ks := keystore.New()
+	if err := ks.SetPrivateKeyEntry(alias, keystore.PrivateKeyEntry{
+		CreationTime: time.Now(),
+		PrivateKey:   privateKeyDER,
+		CertificateChain: []keystore.Certificate{
+			{Type: "X509", Content: leaf.Raw},
+		},
+	}, []byte(password)); err != nil {
+		return nil, fmt.Errorf("setting JKS private key entry: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := ks.Store(&buf, []byte(password)); err != nil {
+		return nil, fmt.Errorf("storing JKS keystore: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// pickLeaf returns the first non-CA certificate from certs (i.e. the end-entity
+// leaf), regardless of position in the chain. As a safety net for chains where
+// no certificate has IsCA=false (which would be unusual for an issued service
+// identity), it falls back to the first certificate. Returns nil if certs is
+// empty.
+func pickLeaf(certs []*x509.Certificate) *x509.Certificate {
+	for _, c := range certs {
+		if !c.IsCA {
+			return c
+		}
+	}
+	if len(certs) > 0 {
+		return certs[0]
+	}
+	return nil
+}
+
+// parseCertChain decodes all CERTIFICATE PEM blocks in data into x509
+// certificates, preserving order.
+func parseCertChain(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, c)
+	}
+	return certs, nil
 }

--- a/internal/csi/driver/keystore_test.go
+++ b/internal/csi/driver/keystore_test.go
@@ -246,7 +246,8 @@ func parseFirstCert(t *testing.T, pemBytes []byte) *x509.Certificate {
 }
 
 // Test_pickLeaf_ChainOrder ensures the leaf is selected by IsCA, not by chain
-// order, so the keystore is robust to chains emitted in any order.
+// order, so the keystore is robust to chains emitted in any order. Picking a
+// genuine non-CA cert must never set the fallback flag.
 func Test_pickLeaf_ChainOrder(t *testing.T) {
 	leaf := &x509.Certificate{IsCA: false}
 	intermediate := &x509.Certificate{IsCA: true}
@@ -260,21 +261,36 @@ func Test_pickLeaf_ChainOrder(t *testing.T) {
 	}
 	for name, chain := range cases {
 		t.Run(name, func(t *testing.T) {
-			require.Same(t, leaf, pickLeaf(chain))
+			got, fellBack := pickLeaf(chain)
+			require.Same(t, leaf, got)
+			require.False(t, fellBack, "should not report fallback when a non-CA cert exists")
 		})
 	}
 }
 
 // Test_pickLeaf_EdgeCases covers the empty input (returns nil) and the
-// all-CA fallback path (returns the first cert as a safety net).
+// all-CA fallback path (returns the first cert as a safety net and flags
+// fellBack=true so the caller can log the anomaly).
 func Test_pickLeaf_EdgeCases(t *testing.T) {
-	require.Nil(t, pickLeaf(nil))
-	require.Nil(t, pickLeaf([]*x509.Certificate{}))
-
-	first := &x509.Certificate{IsCA: true}
-	second := &x509.Certificate{IsCA: true}
-	require.Same(t, first, pickLeaf([]*x509.Certificate{first, second}),
-		"with no non-CA cert, pickLeaf must fall back to the first cert")
+	t.Run("nil-input", func(t *testing.T) {
+		got, fellBack := pickLeaf(nil)
+		require.Nil(t, got)
+		require.False(t, fellBack)
+	})
+	t.Run("empty-input", func(t *testing.T) {
+		got, fellBack := pickLeaf([]*x509.Certificate{})
+		require.Nil(t, got)
+		require.False(t, fellBack)
+	})
+	t.Run("all-ca-fallback", func(t *testing.T) {
+		first := &x509.Certificate{IsCA: true}
+		second := &x509.Certificate{IsCA: true}
+		got, fellBack := pickLeaf([]*x509.Certificate{first, second})
+		require.Same(t, first, got,
+			"with no non-CA cert, pickLeaf must fall back to the first cert")
+		require.True(t, fellBack,
+			"all-CA chain must flag fellBack so the caller can warn")
+	})
 }
 
 // Test_writeKeypair_PicksLeafByIsCA verifies the end-to-end behaviour: when

--- a/internal/csi/driver/keystore_test.go
+++ b/internal/csi/driver/keystore_test.go
@@ -155,6 +155,12 @@ func Test_writeKeypair_JKS(t *testing.T) {
 	expectedLeaf := parseFirstCert(t, leafPEM)
 	require.True(t, bytes.Equal(entry.CertificateChain[0].Content, expectedLeaf.Raw),
 		"leaf certificate in JKS must match the issued leaf")
+
+	// CreationTime is derived from leaf.NotBefore so that re-encoding the
+	// same certificate yields the same JKS metadata, rather than drifting
+	// with wall-clock time on every refresh.
+	require.True(t, entry.CreationTime.Equal(expectedLeaf.NotBefore),
+		"JKS entry CreationTime must equal leaf.NotBefore for determinism")
 }
 
 // Test_writeKeypair_KeystoresDisabled ensures no keystore files are written

--- a/internal/csi/driver/keystore_test.go
+++ b/internal/csi/driver/keystore_test.go
@@ -1,0 +1,342 @@
+/*
+Copyright The Athenz Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"testing"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	utilpki "github.com/cert-manager/cert-manager/pkg/util/pki"
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+	keystore "github.com/pavlo-v-chernykh/keystore-go/v4"
+	"github.com/stretchr/testify/require"
+	pkcs12 "software.sslmate.com/src/go-pkcs12"
+
+	"github.com/AthenZ/csi-driver-athenz/internal/csi/rootca"
+)
+
+// keystoreFixture builds a CA-signed leaf cert/key pair plus a wired-up
+// Driver writing into an in-memory store. The concrete *MemoryFS is also
+// returned so tests can read files back via ReadFiles, which is not part of
+// the storage.Interface contract.
+func keystoreFixture(t *testing.T, opts ...func(*Driver)) (*ecdsa.PrivateKey, []byte, *Driver, *storage.MemoryFS, metadata.Metadata) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	capk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	caTmpl, err := utilpki.CertificateTemplateFromCertificate(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{CommonName: "my-ca"},
+	})
+	require.NoError(t, err)
+
+	caPEM, ca, err := utilpki.SignCertificate(caTmpl, caTmpl, capk.Public(), capk)
+	require.NoError(t, err)
+
+	leafpk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	leafTmpl, err := utilpki.CertificateTemplateFromCertificate(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{
+			URIs: []string{"spiffe://athenz.io/ns/sandbox/sa/default"},
+		},
+	})
+	require.NoError(t, err)
+
+	leafPEM, _, err := utilpki.SignCertificate(leafTmpl, ca, leafpk.Public(), capk)
+	require.NoError(t, err)
+
+	ch := make(chan []byte, 1)
+	rootCAs := rootca.NewMemory(ctx, ch)
+	ch <- caPEM
+
+	store := storage.NewMemoryFS()
+	d := &Driver{
+		certFileName:     "tls.crt",
+		keyFileName:      "tls.key",
+		caFileName:       "ca.crt",
+		keystoreEnabled:  true,
+		keystoreFileName: "service.pkcs12",
+		jksFileName:      "service.jks",
+		keystorePassword: "changeit",
+		keystoreAlias:    "service",
+		rootCAs:          rootCAs,
+		store:            store,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+	_, err = store.RegisterMetadata(meta)
+	require.NoError(t, err)
+
+	return leafpk, leafPEM, d, store, meta
+}
+
+// Test_writeKeypair_PKCS12 verifies the PKCS12 keystore decodes back to the
+// same private key and leaf certificate that were issued, and that no CA /
+// chain certificates leak into the keystore (matching the legacy SIA
+// `openssl pkcs12 -export -inkey -in` behaviour).
+func Test_writeKeypair_PKCS12(t *testing.T) {
+	leafpk, leafPEM, d, store, meta := keystoreFixture(t)
+
+	require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+	require.Contains(t, files, "service.pkcs12")
+
+	gotKey, gotLeaf, caCerts, err := pkcs12.DecodeChain(files["service.pkcs12"], "changeit")
+	require.NoError(t, err)
+	require.Empty(t, caCerts, "PKCS12 should not contain CA / intermediate certs")
+
+	gotECKey, ok := gotKey.(*ecdsa.PrivateKey)
+	require.True(t, ok, "expected ECDSA private key")
+	require.True(t, gotECKey.Equal(leafpk), "private key in PKCS12 must match the issued key")
+
+	expectedLeaf := parseFirstCert(t, leafPEM)
+	require.True(t, bytes.Equal(gotLeaf.Raw, expectedLeaf.Raw),
+		"leaf certificate in PKCS12 must match the issued leaf")
+}
+
+// Test_writeKeypair_JKS verifies the JKS keystore contains exactly one
+// PrivateKeyEntry under the configured alias, holding the same key and leaf
+// certificate as the issued pair, and no extra CA / chain certs.
+func Test_writeKeypair_JKS(t *testing.T) {
+	leafpk, leafPEM, d, store, meta := keystoreFixture(t)
+
+	require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+	require.Contains(t, files, "service.jks")
+
+	ks := keystore.New()
+	require.NoError(t, ks.Load(bytes.NewReader(files["service.jks"]), []byte("changeit")))
+
+	aliases := ks.Aliases()
+	require.Equal(t, []string{"service"}, aliases)
+
+	entry, err := ks.GetPrivateKeyEntry("service", []byte("changeit"))
+	require.NoError(t, err)
+	require.Len(t, entry.CertificateChain, 1, "JKS chain should contain only the leaf")
+
+	gotKey, err := x509.ParsePKCS8PrivateKey(entry.PrivateKey)
+	require.NoError(t, err)
+	gotECKey, ok := gotKey.(*ecdsa.PrivateKey)
+	require.True(t, ok, "expected ECDSA private key")
+	require.True(t, gotECKey.Equal(leafpk), "private key in JKS must match the issued key")
+
+	expectedLeaf := parseFirstCert(t, leafPEM)
+	require.True(t, bytes.Equal(entry.CertificateChain[0].Content, expectedLeaf.Raw),
+		"leaf certificate in JKS must match the issued leaf")
+}
+
+// Test_writeKeypair_KeystoresDisabled ensures no keystore files are written
+// when the master switch is off, even if filenames are configured. This is
+// the default behaviour and guarantees the PEM-only on-disk layout is
+// preserved when the feature is not opted into.
+func Test_writeKeypair_KeystoresDisabled(t *testing.T) {
+	leafpk, leafPEM, d, store, meta := keystoreFixture(t, func(d *Driver) {
+		d.keystoreEnabled = false
+		// Filenames stay populated to prove the master switch overrides them.
+	})
+
+	require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+	require.NotContains(t, files, "service.pkcs12")
+	require.NotContains(t, files, "service.jks")
+	require.Contains(t, files, "tls.crt")
+	require.Contains(t, files, "tls.key")
+}
+
+// Test_writeKeypair_KeystoresEnabledSelectiveSkip ensures that with the
+// master switch on, an individual keystore can still be skipped by setting
+// its filename to the empty string.
+func Test_writeKeypair_KeystoresEnabledSelectiveSkip(t *testing.T) {
+	t.Run("only-pkcs12", func(t *testing.T) {
+		leafpk, leafPEM, d, store, meta := keystoreFixture(t, func(d *Driver) {
+			d.jksFileName = ""
+		})
+		require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+		files, err := store.ReadFiles("vol-id")
+		require.NoError(t, err)
+		require.Contains(t, files, "service.pkcs12")
+		require.NotContains(t, files, "service.jks")
+	})
+	t.Run("only-jks", func(t *testing.T) {
+		leafpk, leafPEM, d, store, meta := keystoreFixture(t, func(d *Driver) {
+			d.keystoreFileName = ""
+		})
+		require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+		files, err := store.ReadFiles("vol-id")
+		require.NoError(t, err)
+		require.NotContains(t, files, "service.pkcs12")
+		require.Contains(t, files, "service.jks")
+	})
+}
+
+// Test_writeKeypair_KeystoresMatch cross-validates that the PKCS12 and JKS
+// keystores written in the same refresh round expose identical key/cert
+// material. This guards against any future divergence between the two
+// encoders that could leave one stale relative to the other.
+func Test_writeKeypair_KeystoresMatch(t *testing.T) {
+	leafpk, leafPEM, d, store, meta := keystoreFixture(t)
+
+	require.NoError(t, d.writeKeypair(meta, leafpk, leafPEM, nil))
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+
+	p12Key, p12Leaf, _, err := pkcs12.DecodeChain(files["service.pkcs12"], "changeit")
+	require.NoError(t, err)
+
+	ks := keystore.New()
+	require.NoError(t, ks.Load(bytes.NewReader(files["service.jks"]), []byte("changeit")))
+	jksEntry, err := ks.GetPrivateKeyEntry("service", []byte("changeit"))
+	require.NoError(t, err)
+	jksKey, err := x509.ParsePKCS8PrivateKey(jksEntry.PrivateKey)
+	require.NoError(t, err)
+
+	require.True(t, p12Key.(*ecdsa.PrivateKey).Equal(jksKey.(*ecdsa.PrivateKey)),
+		"PKCS12 and JKS must wrap the same private key")
+	require.True(t, bytes.Equal(p12Leaf.Raw, jksEntry.CertificateChain[0].Content),
+		"PKCS12 and JKS must wrap the same leaf certificate")
+}
+
+func parseFirstCert(t *testing.T, pemBytes []byte) *x509.Certificate {
+	t.Helper()
+	certs, err := parseCertChain(pemBytes)
+	require.NoError(t, err)
+	require.NotEmpty(t, certs)
+	return certs[0]
+}
+
+// Test_pickLeaf_ChainOrder ensures the leaf is selected by IsCA, not by chain
+// order, so the keystore is robust to chains emitted in any order.
+func Test_pickLeaf_ChainOrder(t *testing.T) {
+	leaf := &x509.Certificate{IsCA: false}
+	intermediate := &x509.Certificate{IsCA: true}
+	root := &x509.Certificate{IsCA: true}
+
+	cases := map[string][]*x509.Certificate{
+		"leaf-first":             {leaf, intermediate, root},
+		"intermediate-then-leaf": {intermediate, leaf, root},
+		"leaf-last":              {root, intermediate, leaf},
+		"leaf-only":              {leaf},
+	}
+	for name, chain := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Same(t, leaf, pickLeaf(chain))
+		})
+	}
+}
+
+// Test_pickLeaf_EdgeCases covers the empty input (returns nil) and the
+// all-CA fallback path (returns the first cert as a safety net).
+func Test_pickLeaf_EdgeCases(t *testing.T) {
+	require.Nil(t, pickLeaf(nil))
+	require.Nil(t, pickLeaf([]*x509.Certificate{}))
+
+	first := &x509.Certificate{IsCA: true}
+	second := &x509.Certificate{IsCA: true}
+	require.Same(t, first, pickLeaf([]*x509.Certificate{first, second}),
+		"with no non-CA cert, pickLeaf must fall back to the first cert")
+}
+
+// Test_writeKeypair_PicksLeafByIsCA verifies the end-to-end behaviour: when
+// writeKeypair receives a PEM chain in [intermediate, leaf] order, both
+// keystores still contain the leaf (not the intermediate).
+func Test_writeKeypair_PicksLeafByIsCA(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	capk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl, err := utilpki.CertificateTemplateFromCertificate(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{CommonName: "my-ca", IsCA: true},
+	})
+	require.NoError(t, err)
+	caPEM, ca, err := utilpki.SignCertificate(caTmpl, caTmpl, capk.Public(), capk)
+	require.NoError(t, err)
+
+	leafpk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl, err := utilpki.CertificateTemplateFromCertificate(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{URIs: []string{"spiffe://athenz.io/ns/sandbox/sa/default"}},
+	})
+	require.NoError(t, err)
+	leafPEM, _, err := utilpki.SignCertificate(leafTmpl, ca, leafpk.Public(), capk)
+	require.NoError(t, err)
+
+	// Build a chain in non-leaf-first order: [intermediate(=CA), leaf].
+	swappedChain := append([]byte{}, caPEM...)
+	swappedChain = append(swappedChain, leafPEM...)
+
+	ch := make(chan []byte, 1)
+	rootCAs := rootca.NewMemory(ctx, ch)
+	ch <- caPEM
+	store := storage.NewMemoryFS()
+	d := &Driver{
+		certFileName:     "tls.crt",
+		keyFileName:      "tls.key",
+		caFileName:       "ca.crt",
+		keystoreEnabled:  true,
+		keystoreFileName: "service.pkcs12",
+		jksFileName:      "service.jks",
+		keystorePassword: "changeit",
+		keystoreAlias:    "service",
+		rootCAs:          rootCAs,
+		store:            store,
+	}
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+	_, err = store.RegisterMetadata(meta)
+	require.NoError(t, err)
+
+	require.NoError(t, d.writeKeypair(meta, leafpk, swappedChain, nil))
+
+	files, err := store.ReadFiles("vol-id")
+	require.NoError(t, err)
+
+	expectedLeaf := parseFirstCert(t, leafPEM)
+
+	_, p12Leaf, _, err := pkcs12.DecodeChain(files["service.pkcs12"], "changeit")
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(p12Leaf.Raw, expectedLeaf.Raw),
+		"PKCS12 must contain the leaf even when the chain is not leaf-first")
+
+	ks := keystore.New()
+	require.NoError(t, ks.Load(bytes.NewReader(files["service.jks"]), []byte("changeit")))
+	jksEntry, err := ks.GetPrivateKeyEntry("service", []byte("changeit"))
+	require.NoError(t, err)
+	require.Len(t, jksEntry.CertificateChain, 1)
+	require.True(t, bytes.Equal(jksEntry.CertificateChain[0].Content, expectedLeaf.Raw),
+		"JKS must contain the leaf even when the chain is not leaf-first")
+}


### PR DESCRIPTION
Add opt-in PKCS12 and JKS keystore provisioning

## GOAL

Provision PKCS12 (`service.pkcs12`) and JKS (`service.jks`) keystores alongside the existing PEM identity files (`tls.crt` / `tls.key` / `ca.crt`) so that Java consumers expecting the legacy Athenz SIA on-disk layout can run unchanged on top of csi-driver-athenz, without needing a sidecar or shell hook that runs `openssl pkcs12 -export` + `keytool -importkeystore` after every cert refresh.

The feature is **disabled by default** behind a new `--enable-keystore` master switch. When the flag is `false` (the default), runtime behaviour is byte-for-byte identical to the previous release: only the three PEM files are written.


### New flags

| Flag | Default | Purpose |
|---|---|---|
| `--enable-keystore` | `false` | Master switch; required to write any keystore |
| `--file-name-keystore` | `service.pkcs12` | PKCS12 filename (empty string skips PKCS12 only) |
| `--file-name-jks` | `service.jks` | JKS filename (empty string skips JKS only) |
| `--keystore-password` | `changeit` | Encryption password for both keystores |
| `--keystore-alias` | `service` | JKS private-key entry alias |

## Tests

Unit tests in `internal/csi/driver/keystore_test.go`:

- `Test_writeKeypair_PKCS12` — decode PKCS12, assert private key + leaf match the issued material, no CA / chain certs leak in
- `Test_writeKeypair_JKS` — load JKS, assert single alias `service`, single-cert chain matches the leaf, private key parses as PKCS8
- `Test_writeKeypair_KeystoresMatch` — cross-check that PKCS12 and JKS written in the same refresh round wrap identical key + leaf bytes
- `Test_writeKeypair_KeystoresDisabled` — with `--enable-keystore=false` and filenames still set, no keystore files are written (master-switch regression guard)
- `Test_writeKeypair_KeystoresEnabledSelectiveSkip` — with the master switch on, setting either filename to empty disables that one keystore individually
- `Test_pickLeaf_ChainOrder` (sub-tests for `leaf-first` / `intermediate-then-leaf` / `leaf-last` / `leaf-only`) — leaf is selected by `IsCA`, not by chain position
- `Test_pickLeaf_EdgeCases` — empty input → `nil`; all-CA fallback returns the first cert as a safety net
- `Test_writeKeypair_PicksLeafByIsCA` — end-to-end: chain in `[CA, leaf]` order still produces keystores containing the leaf

Manual verification on nonprod cluster.
- Built and pushed image `docker.ouroath.com:4443/ychuang/athenz-csi-driver:v0.0.13-pkcs12.3d8a90c`
- Rolled the `kube-addons/csi-driver-athenz` DaemonSet (6/6 healthy)
- Verified atomic refresh: all five files (`tls.crt` / `tls.key` / `ca.crt` / `service.pkcs12` / `service.jks`) share the same `..data` symlink target
- Pulled `service.pkcs12` + `service.jks` + `cert.pem` from a consumer pod and confirmed:
  - PKCS12 algo = `pbeWithSHA1And40BitRC2-CBC`, MAC iteration = 1
  - PKCS12 leaf SHA256 matches `cert.pem` exactly, cert count = 1 (no CA)
  - JKS contains a single alias `service`, leaf SHA256 matches `cert.pem`, private key parses as PKCS8


## Ref
