### PR TITLE
Expose PKCS12 / JKS keystore options through the helm chart

### DIFF
--- a/deploy/charts/csi-driver-athenz/README.md
+++ b/deploy/charts/csi-driver-athenz/README.md
@@ -155,6 +155,45 @@ managed volumes.
 > ```
 
 -- File name where the CA bundles are written to, if enabled.
+#### **app.driver.keystore.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+-- Master switch for PKCS12 / JKS keystore provisioning.
+#### **app.driver.keystore.pkcs12FileName** ~ `string`
+> Default value:
+> ```yaml
+> service.pkcs12
+> ```
+
+-- File name of the PKCS12 keystore written into the pod's volume.  
+Set to an empty string to skip PKCS12 generation while still writing the JKS keystore. The keystore uses the legacy PKCS12 encoding to mirror `openssl pkcs12 -export -noiter -nomaciter` so old Java JREs remain compatible.
+#### **app.driver.keystore.jksFileName** ~ `string`
+> Default value:
+> ```yaml
+> service.jks
+> ```
+
+-- File name of the JKS keystore written into the pod's volume. Set  
+to an empty string to skip JKS generation while still writing the  
+PKCS12 keystore.
+#### **app.driver.keystore.passwordFile** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+-- File path inside the driver container whose contents are read as  
+the keystore password. Typically the mount path of a Secret-backed volume. When empty, the well-known Java default `changeit` is used. The password may also be supplied via the `KEYSTORE_PASSWORD` environment variable, which takes precedence over this file. The password is never accepted on the command line, to avoid leaking it via `ps`.
+#### **app.driver.keystore.alias** ~ `string`
+> Default value:
+> ```yaml
+> service
+> ```
+
+-- Alias used for the private key entry inside the JKS keystore.
 #### **app.driver.volumes** ~ `array`
 > Default value:
 > ```yaml
@@ -427,4 +466,70 @@ Additional labels to give the ServiceMonitor resource.
 > ```
 
 Labels to apply to all resources
+#### **nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> kubernetes.io/os: linux
+> ```
+
+Kubernetes node selector: node labels for pod assignment.
+
+#### **affinity** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes affinity: constraints for pod assignment.  
+  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+#### **tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.  
+  
+For example:
+
+```yaml
+tolerations:
+- key: foo.bar.com/role
+  operator: Equal
+  value: master
+  effect: NoSchedule
+```
+#### **topologySpreadConstraints** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes TopologySpreadConstraints.  
+  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 2
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: controller
+```
 

--- a/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
@@ -94,6 +94,16 @@ spec:
             - --cloud-provider={{ .Values.app.athenz.cloudProvider }}
             - --cloud-region={{ .Values.app.athenz.cloudRegion }}
 
+          {{- if .Values.app.driver.keystore.enabled }}
+            - --enable-keystore
+            - --file-name-keystore={{ .Values.app.driver.keystore.pkcs12FileName }}
+            - --file-name-jks={{ .Values.app.driver.keystore.jksFileName }}
+            - --keystore-alias={{ .Values.app.driver.keystore.alias }}
+          {{- if .Values.app.driver.keystore.passwordFile }}
+            - --keystore-password-file={{ .Values.app.driver.keystore.passwordFile }}
+          {{- end }}
+          {{- end }}
+
           env:
             - name: NODE_ID
               valueFrom:

--- a/deploy/charts/csi-driver-athenz/values.schema.json
+++ b/deploy/charts/csi-driver-athenz/values.schema.json
@@ -1,9 +1,7 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/$defs/helm-values",
   "$defs": {
     "helm-values": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "affinity": {
           "$ref": "#/$defs/helm-values.affinity"
@@ -36,15 +34,15 @@
           "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.affinity": {
+      "default": {},
       "description": "Kubernetes affinity: constraints for pod assignment.\n\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
-      "type": "object",
-      "default": {}
+      "type": "object"
     },
     "helm-values.app": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "approver": {
           "$ref": "#/$defs/helm-values.app.approver"
@@ -74,10 +72,10 @@
           "$ref": "#/$defs/helm-values.app.trustDomain"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "metrics": {
           "$ref": "#/$defs/helm-values.app.approver.metrics"
@@ -98,10 +96,10 @@
           "$ref": "#/$defs/helm-values.app.approver.signerName"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver.metrics": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "port": {
           "$ref": "#/$defs/helm-values.app.approver.metrics.port"
@@ -110,15 +108,15 @@
           "$ref": "#/$defs/helm-values.app.approver.metrics.service"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver.metrics.port": {
+      "default": 9402,
       "description": "-- Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.",
-      "type": "number",
-      "default": 9402
+      "type": "number"
     },
     "helm-values.app.approver.metrics.service": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.app.approver.metrics.service.enabled"
@@ -130,15 +128,15 @@
           "$ref": "#/$defs/helm-values.app.approver.metrics.service.type"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver.metrics.service.enabled": {
+      "default": true,
       "description": "-- Create a Service resource to expose metrics endpoint.",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "helm-values.app.approver.metrics.service.servicemonitor": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.app.approver.metrics.service.servicemonitor.enabled"
@@ -156,72 +154,72 @@
           "$ref": "#/$defs/helm-values.app.approver.metrics.service.servicemonitor.scrapeTimeout"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver.metrics.service.servicemonitor.enabled": {
+      "default": false,
       "description": "Create Prometheus ServiceMonitor resource for csi-driver-athenz approver.",
-      "type": "boolean",
-      "default": false
+      "type": "boolean"
     },
     "helm-values.app.approver.metrics.service.servicemonitor.interval": {
+      "default": "10s",
       "description": "The interval that the Prometheus will scrape for metrics.",
-      "type": "string",
-      "default": "10s"
+      "type": "string"
     },
     "helm-values.app.approver.metrics.service.servicemonitor.labels": {
+      "default": {},
       "description": "Additional labels to give the ServiceMonitor resource.",
-      "type": "object",
-      "default": {}
+      "type": "object"
     },
     "helm-values.app.approver.metrics.service.servicemonitor.prometheusInstance": {
+      "default": "default",
       "description": "The value for the \"prometheus\" label on the ServiceMonitor. This allows for multiple Prometheus instances selecting difference ServiceMonitors using label selectors.",
-      "type": "string",
-      "default": "default"
+      "type": "string"
     },
     "helm-values.app.approver.metrics.service.servicemonitor.scrapeTimeout": {
+      "default": "5s",
       "description": "The timeout on each metric probe request.",
-      "type": "string",
-      "default": "5s"
+      "type": "string"
     },
     "helm-values.app.approver.metrics.service.type": {
+      "default": "ClusterIP",
       "description": "-- Service type to expose metrics.",
-      "type": "string",
-      "default": "ClusterIP"
+      "type": "string"
     },
     "helm-values.app.approver.multiTenant": {
-      "type": "boolean",
-      "default": false
+      "default": false,
+      "type": "boolean"
     },
     "helm-values.app.approver.readinessProbe": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "port": {
           "$ref": "#/$defs/helm-values.app.approver.readinessProbe.port"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.approver.readinessProbe.port": {
+      "default": 6060,
       "description": "-- Container port to expose csi-driver-athenz-approver HTTP readiness\nprobe on default network interface.",
-      "type": "number",
-      "default": 6060
+      "type": "number"
     },
     "helm-values.app.approver.replicaCount": {
+      "default": 1,
       "description": "-- Number of replicas of the approver to run.",
-      "type": "number",
-      "default": 1
+      "type": "number"
     },
     "helm-values.app.approver.resources": {
-      "type": "object",
-      "default": {}
+      "default": {},
+      "type": "object"
     },
     "helm-values.app.approver.signerName": {
+      "default": "clusterissuers.cert-manager.io/*",
       "description": "-- The signer name that csi-driver-athenz approver will be given\npermission to approve and deny. CertificateRequests referencing this signer name can be processed by the Athenz approver. See: https://cert-manager.io/docs/concepts/certificaterequest/#approval",
-      "type": "string",
-      "default": "clusterissuers.cert-manager.io/*"
+      "type": "string"
     },
     "helm-values.app.athenz": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "caCertFile": {
           "$ref": "#/$defs/helm-values.app.athenz.caCertFile"
@@ -248,7 +246,7 @@
           "$ref": "#/$defs/helm-values.app.athenz.zts"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.athenz.caCertFile": {
       "description": "-- Optional ZTS CA bundle"
@@ -275,15 +273,18 @@
       "description": "-- Athenz ZTS endpoint"
     },
     "helm-values.app.certificateRequestDuration": {
+      "default": "1h",
       "description": "-- Duration requested for requested certificates.",
-      "type": "string",
-      "default": "1h"
+      "type": "string"
     },
     "helm-values.app.driver": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "csiDataDir": {
           "$ref": "#/$defs/helm-values.app.driver.csiDataDir"
+        },
+        "keystore": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore"
         },
         "livenessProbe": {
           "$ref": "#/$defs/helm-values.app.driver.livenessProbe"
@@ -310,29 +311,75 @@
           "$ref": "#/$defs/helm-values.app.driver.volumes"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.driver.csiDataDir": {
+      "default": "/tmp/csi-driver-athenz",
       "description": "-- Configures the hostPath directory that the driver will write and mount volumes from.",
-      "type": "string",
-      "default": "/tmp/csi-driver-athenz"
+      "type": "string"
+    },
+    "helm-values.app.driver.keystore": {
+      "additionalProperties": false,
+      "properties": {
+        "alias": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore.alias"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore.enabled"
+        },
+        "jksFileName": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore.jksFileName"
+        },
+        "passwordFile": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore.passwordFile"
+        },
+        "pkcs12FileName": {
+          "$ref": "#/$defs/helm-values.app.driver.keystore.pkcs12FileName"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.driver.keystore.alias": {
+      "default": "service",
+      "description": "-- Alias used for the private key entry inside the JKS keystore.",
+      "type": "string"
+    },
+    "helm-values.app.driver.keystore.enabled": {
+      "default": false,
+      "description": "-- Master switch for PKCS12 / JKS keystore provisioning.",
+      "type": "boolean"
+    },
+    "helm-values.app.driver.keystore.jksFileName": {
+      "default": "service.jks",
+      "description": "-- File name of the JKS keystore written into the pod's volume. Set\nto an empty string to skip JKS generation while still writing the\nPKCS12 keystore.",
+      "type": "string"
+    },
+    "helm-values.app.driver.keystore.passwordFile": {
+      "default": "",
+      "description": "-- File path inside the driver container whose contents are read as\nthe keystore password. Typically the mount path of a Secret-backed volume. When empty, the well-known Java default `changeit` is used. The password may also be supplied via the `KEYSTORE_PASSWORD` environment variable, which takes precedence over this file. The password is never accepted on the command line, to avoid leaking it via `ps`.",
+      "type": "string"
+    },
+    "helm-values.app.driver.keystore.pkcs12FileName": {
+      "default": "service.pkcs12",
+      "description": "-- File name of the PKCS12 keystore written into the pod's volume.\nSet to an empty string to skip PKCS12 generation while still writing the JKS keystore. The keystore uses the legacy PKCS12 encoding to mirror `openssl pkcs12 -export -noiter -nomaciter` so old Java JREs remain compatible.",
+      "type": "string"
     },
     "helm-values.app.driver.livenessProbe": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "port": {
           "$ref": "#/$defs/helm-values.app.driver.livenessProbe.port"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.driver.livenessProbe.port": {
+      "default": 9809,
       "description": "-- The port that will expose the liveness of the csi-driver",
-      "type": "number",
-      "default": 9809
+      "type": "number"
     },
     "helm-values.app.driver.livenessProbeImage": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "pullPolicy": {
           "$ref": "#/$defs/helm-values.app.driver.livenessProbeImage.pullPolicy"
@@ -347,29 +394,29 @@
           "$ref": "#/$defs/helm-values.app.driver.livenessProbeImage.tag"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.driver.livenessProbeImage.pullPolicy": {
+      "default": "IfNotPresent",
       "description": "-- Kubernetes imagePullPolicy on liveness probe.",
-      "type": "string",
-      "default": "IfNotPresent"
+      "type": "string"
     },
     "helm-values.app.driver.livenessProbeImage.registry": {
       "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: registry.k8s.io\nrepository: sig-storage/livenessprobe",
       "type": "string"
     },
     "helm-values.app.driver.livenessProbeImage.repository": {
+      "default": "registry.k8s.io/sig-storage/livenessprobe",
       "description": "-- Target image repository.",
-      "type": "string",
-      "default": "registry.k8s.io/sig-storage/livenessprobe"
+      "type": "string"
     },
     "helm-values.app.driver.livenessProbeImage.tag": {
+      "default": "v2.12.0",
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
-      "type": "string",
-      "default": "v2.12.0"
+      "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "digest": {
           "$ref": "#/$defs/helm-values.app.driver.nodeDriverRegistrarImage.digest"
@@ -387,40 +434,40 @@
           "$ref": "#/$defs/helm-values.app.driver.nodeDriverRegistrarImage.tag"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.digest": {
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
       "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.pullPolicy": {
+      "default": "IfNotPresent",
       "description": "Kubernetes imagePullPolicy on node-driver.",
-      "type": "string",
-      "default": "IfNotPresent"
+      "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.registry": {
       "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: registry.k8s.io\nrepository: sig-storage/csi-node-driver-registrar",
       "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.repository": {
+      "default": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
       "description": "-- Target image repository.",
-      "type": "string",
-      "default": "registry.k8s.io/sig-storage/csi-node-driver-registrar"
+      "type": "string"
     },
     "helm-values.app.driver.nodeDriverRegistrarImage.tag": {
+      "default": "v2.11.1",
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
-      "type": "string",
-      "default": "v2.11.1"
+      "type": "string"
     },
     "helm-values.app.driver.resources": {
-      "type": "object",
-      "default": {}
+      "default": {},
+      "type": "object"
     },
     "helm-values.app.driver.sourceCABundle": {
       "description": "-- Optional file containing a CA bundle that will be propagated to\nmanaged volumes."
     },
     "helm-values.app.driver.volumeFileName": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "ca": {
           "$ref": "#/$defs/helm-values.app.driver.volumeFileName.ca"
@@ -432,40 +479,40 @@
           "$ref": "#/$defs/helm-values.app.driver.volumeFileName.key"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.driver.volumeFileName.ca": {
+      "default": "ca.crt",
       "description": "-- File name where the CA bundles are written to, if enabled.",
-      "type": "string",
-      "default": "ca.crt"
+      "type": "string"
     },
     "helm-values.app.driver.volumeFileName.cert": {
+      "default": "tls.crt",
       "description": "-- File name which signed certificates are written to in volumes.",
-      "type": "string",
-      "default": "tls.crt"
+      "type": "string"
     },
     "helm-values.app.driver.volumeFileName.key": {
+      "default": "tls.key",
       "description": "-- File name which private keys are written to in volumes.",
-      "type": "string",
-      "default": "tls.key"
+      "type": "string"
     },
     "helm-values.app.driver.volumeMounts": {
-      "description": "- name: root-cas\nsecret:\n  secretName: root-ca-bundle\n-- Optional extra volume mounts. Useful for mounting root CAs",
-      "type": "array",
       "default": [],
-      "items": {}
+      "description": "- name: root-cas\nsecret:\n  secretName: root-ca-bundle\n-- Optional extra volume mounts. Useful for mounting root CAs",
+      "items": {},
+      "type": "array"
     },
     "helm-values.app.driver.volumes": {
-      "description": "-- Optional extra volumes. Useful for mounting root CAs",
-      "type": "array",
       "default": [],
-      "items": {}
+      "description": "-- Optional extra volumes. Useful for mounting root CAs",
+      "items": {},
+      "type": "array"
     },
     "helm-values.app.extraCertificateRequestAnnotations": {
       "description": "List of annotations to add to certificate requests\n\nFor example:\nextraCertificateRequestAnnotations: app=csi-driver-athenz,foo=bar"
     },
     "helm-values.app.issuer": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "group": {
           "$ref": "#/$defs/helm-values.app.issuer.group"
@@ -477,48 +524,48 @@
           "$ref": "#/$defs/helm-values.app.issuer.name"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.app.issuer.group": {
+      "default": "cert-manager.io",
       "description": "-- Issuer group which is used to serve this Trust Domain.",
-      "type": "string",
-      "default": "cert-manager.io"
+      "type": "string"
     },
     "helm-values.app.issuer.kind": {
+      "default": "ClusterIssuer",
       "description": "-- Issuer kind which is used to serve this Trust Domain.",
-      "type": "string",
-      "default": "ClusterIssuer"
+      "type": "string"
     },
     "helm-values.app.issuer.name": {
+      "default": "athenz-ca",
       "description": "-- Issuer name which is used to serve this Trust Domain.",
-      "type": "string",
-      "default": "athenz-ca"
+      "type": "string"
     },
     "helm-values.app.logLevel": {
+      "default": 1,
       "description": "-- Verbosity of cert-manager-csi-driver logging.",
-      "type": "number",
-      "default": 1
+      "type": "number"
     },
     "helm-values.app.name": {
+      "default": "csi.cert-manager.athenz.io",
       "description": "-- The name for the CSI driver installation.",
-      "type": "string",
-      "default": "csi.cert-manager.athenz.io"
+      "type": "string"
     },
     "helm-values.app.trustDomain": {
+      "default": "cluster.local",
       "description": "-- The Trust Domain for this driver.",
-      "type": "string",
-      "default": "cluster.local"
+      "type": "string"
     },
     "helm-values.commonLabels": {
+      "default": {},
       "description": "Labels to apply to all resources",
-      "type": "object",
-      "default": {}
+      "type": "object"
     },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"
     },
     "helm-values.image": {
-      "type": "object",
+      "additionalProperties": false,
       "properties": {
         "digest": {
           "$ref": "#/$defs/helm-values.image.digest"
@@ -533,10 +580,10 @@
           "$ref": "#/$defs/helm-values.image.tag"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.image.digest": {
-      "type": "object",
+      "additionalProperties": false,
       "default": {},
       "properties": {
         "approver": {
@@ -546,7 +593,7 @@
           "$ref": "#/$defs/helm-values.image.digest.driver"
         }
       },
-      "additionalProperties": false
+      "type": "object"
     },
     "helm-values.image.digest.approver": {
       "description": "Target csi-driver approver digest. Override any tag, if set.\nFor example:\napprover: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
@@ -557,51 +604,53 @@
       "type": "string"
     },
     "helm-values.image.pullPolicy": {
+      "default": "IfNotPresent",
       "description": "-- Kubernetes imagePullPolicy on DaemonSet.",
-      "type": "string",
-      "default": "IfNotPresent"
+      "type": "string"
     },
     "helm-values.image.repository": {
-      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: docker.io\nrepository:\n  driver: athenz/athenz-csi-driver\n  approver: athenz/athenz-csi-driver-approver\nregistry: docker.io",
-      "type": "object",
       "default": {
         "approver": "docker.io/athenz/athenz-csi-driver-approver",
         "driver": "docker.io/athenz/athenz-csi-driver"
-      }
+      },
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: docker.io\nrepository:\n  driver: athenz/athenz-csi-driver\n  approver: athenz/athenz-csi-driver-approver\nregistry: docker.io",
+      "type": "object"
     },
     "helm-values.image.tag": {
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },
     "helm-values.imagePullSecrets": {
-      "description": "-- Optional secrets used for pulling the csi-driver-athenz and csi-driver-athenz-approver container images",
-      "type": "array",
       "default": [],
-      "items": {}
+      "description": "-- Optional secrets used for pulling the csi-driver-athenz and csi-driver-athenz-approver container images",
+      "items": {},
+      "type": "array"
     },
     "helm-values.nodeSelector": {
-      "description": "Kubernetes node selector: node labels for pod assignment.",
-      "type": "object",
       "default": {
         "kubernetes.io/os": "linux"
-      }
+      },
+      "description": "Kubernetes node selector: node labels for pod assignment.",
+      "type": "object"
     },
     "helm-values.priorityClassName": {
+      "default": "",
       "description": "-- Optional priority class to be used for the csi-driver pods.",
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "helm-values.tolerations": {
-      "description": "Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
-      "type": "array",
       "default": [],
-      "items": {}
+      "description": "Kubernetes pod tolerations for cert-manager-csi-driver-spiffe.\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "items": {},
+      "type": "array"
     },
     "helm-values.topologySpreadConstraints": {
-      "description": "List of Kubernetes TopologySpreadConstraints.\n\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/instance: cert-manager\n      app.kubernetes.io/component: controller",
-      "type": "array",
       "default": [],
-      "items": {}
+      "description": "List of Kubernetes TopologySpreadConstraints.\n\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/instance: cert-manager\n      app.kubernetes.io/component: controller",
+      "items": {},
+      "type": "array"
     }
-  }
+  },
+  "$ref": "#/$defs/helm-values",
+  "$schema": "http://json-schema.org/draft-07/schema#"
 }

--- a/deploy/charts/csi-driver-athenz/values.yaml
+++ b/deploy/charts/csi-driver-athenz/values.yaml
@@ -72,6 +72,36 @@ app:
       key: tls.key
       # -- File name where the CA bundles are written to, if enabled.
       ca: ca.crt
+
+    # Opt-in provisioning of PKCS12 and JKS keystores alongside the PEM
+    # identity files. When `enabled` is false (the default), no keystores
+    # are written and the rest of the fields in this block have no effect.
+    # Java consumers that expect the legacy Athenz SIA on-disk layout
+    # (`service.pkcs12` + `service.jks`) can opt in here without needing a
+    # sidecar or shell hook.
+    keystore:
+      # -- Master switch for PKCS12 / JKS keystore provisioning.
+      enabled: false
+      # -- File name of the PKCS12 keystore written into the pod's volume.
+      # Set to an empty string to skip PKCS12 generation while still writing
+      # the JKS keystore. The keystore uses the legacy PKCS12 encoding to
+      # mirror `openssl pkcs12 -export -noiter -nomaciter` so old Java JREs
+      # remain compatible.
+      pkcs12FileName: service.pkcs12
+      # -- File name of the JKS keystore written into the pod's volume. Set
+      # to an empty string to skip JKS generation while still writing the
+      # PKCS12 keystore.
+      jksFileName: service.jks
+      # -- File path inside the driver container whose contents are read as
+      # the keystore password. Typically the mount path of a Secret-backed
+      # volume. When empty, the well-known Java default `changeit` is used.
+      # The password may also be supplied via the `KEYSTORE_PASSWORD`
+      # environment variable, which takes precedence over this file. The
+      # password is never accepted on the command line, to avoid leaking it
+      # via `ps`.
+      passwordFile: ""
+      # -- Alias used for the private key entry inside the JKS keystore.
+      alias: service
     # -- Optional extra volumes. Useful for mounting root CAs
     volumes: []
     #- name: root-cas


### PR DESCRIPTION
## Summary

Follow-up to #94 (merged as `f22d361`).

Without this, the new `--enable-keystore` / `--file-name-keystore` / `--file-name-jks` / `--keystore-password-file` / `--keystore-alias` flags introduced in #94 are only reachable by hand-patching the rendered DaemonSet, which gets clobbered on the next `helm upgrade`. That leaves every helm-managed cluster (including the Yahoo-internal fleks/kdnc addons that wrap this chart) unable to opt into the feature without forking the chart.

This PR was a single commit on the original branch that landed after the merge; opening it here as a clean follow-up against the post-merge `main`.

## Changes

Adds a typed `app.driver.keystore` values block:

```yaml
app:
  driver:
    keystore:
      enabled: false           # master switch
      pkcs12FileName: service.pkcs12
      jksFileName:    service.jks
      passwordFile:   ""       # mount a Secret and point here
      alias:          service
```

The daemonset template conditionally appends the matching flags only when `enabled: true`, and only forwards `--keystore-password-file` when a path is actually configured. With the feature left at its default (disabled), the rendered manifest is byte-for-byte identical to the previous release, so existing deployments see no behaviour change.

`README.md` and `values.schema.json` are regenerated via the standard `make generate-helm-docs generate-helm-schema` targets.

## Verification

- `make generate-helm-docs generate-helm-schema` — clean (cherry-pick + re-regen against current main produces zero diff)
- `helm template ... --set app.driver.keystore.enabled=true --set app.driver.keystore.passwordFile=/secrets/pw` — renders all 5 keystore flags as expected
- `helm template ...` (defaults) — renders zero keystore flags, byte-identical to pre-#94 behaviour

## Reviewers

@psasidhar