### PR TITLE
Add in-place volume write mode to keep pod inotify watches alive

### DIFF
--- a/deploy/charts/csi-driver-athenz/README.md
+++ b/deploy/charts/csi-driver-athenz/README.md
@@ -158,12 +158,12 @@ managed volumes.
 #### **app.driver.volumeWriteMode** ~ `string`
 > Default value:
 > ```yaml
-> in-place
+> atomic-dir
 > ```
 
 -- Controls how certificate data is written into pod volumes.  
-`in-place` (default) rewrites existing files so consumer inotify  
-watches survive renewals. `atomic-dir` restores the upstream csi-lib timestamped-directory writer as a rollback path, and silently breaks raw-inotify consumers such as istio-agent on every renewal.
+`atomic-dir` (default) is the upstream csi-lib timestamped-directory  
+writer; it silently breaks raw-inotify consumers such as istio-agent on every renewal, because replacing a file destroys the watched inode. `in-place` rewrites existing files instead, so those watches survive renewals.
 #### **app.driver.keystore.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-athenz/README.md
+++ b/deploy/charts/csi-driver-athenz/README.md
@@ -155,6 +155,15 @@ managed volumes.
 > ```
 
 -- File name where the CA bundles are written to, if enabled.
+#### **app.driver.volumeWriteMode** ~ `string`
+> Default value:
+> ```yaml
+> in-place
+> ```
+
+-- Controls how certificate data is written into pod volumes.  
+`in-place` (default) rewrites existing files so consumer inotify  
+watches survive renewals. `atomic-dir` restores the upstream csi-lib timestamped-directory writer as a rollback path, and silently breaks raw-inotify consumers such as istio-agent on every renewal.
 #### **app.driver.keystore.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
@@ -76,6 +76,7 @@ spec:
             - --file-name-key={{ .Values.app.driver.volumeFileName.key }}
             - --file-name-ca={{ .Values.app.driver.volumeFileName.ca }}
             - --source-ca-bundle={{ .Values.app.driver.sourceCABundle }}
+            - --volume-write-mode={{ .Values.app.driver.volumeWriteMode | default "in-place" }}
 
             - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
+++ b/deploy/charts/csi-driver-athenz/templates/daemonset.yaml
@@ -76,7 +76,7 @@ spec:
             - --file-name-key={{ .Values.app.driver.volumeFileName.key }}
             - --file-name-ca={{ .Values.app.driver.volumeFileName.ca }}
             - --source-ca-bundle={{ .Values.app.driver.sourceCABundle }}
-            - --volume-write-mode={{ .Values.app.driver.volumeWriteMode | default "in-place" }}
+            - --volume-write-mode={{ .Values.app.driver.volumeWriteMode | default "atomic-dir" }}
 
             - --node-id=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/charts/csi-driver-athenz/values.schema.json
+++ b/deploy/charts/csi-driver-athenz/values.schema.json
@@ -307,6 +307,9 @@
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.app.driver.volumeMounts"
         },
+        "volumeWriteMode": {
+          "$ref": "#/$defs/helm-values.app.driver.volumeWriteMode"
+        },
         "volumes": {
           "$ref": "#/$defs/helm-values.app.driver.volumes"
         }
@@ -501,6 +504,11 @@
       "description": "- name: root-cas\nsecret:\n  secretName: root-ca-bundle\n-- Optional extra volume mounts. Useful for mounting root CAs",
       "items": {},
       "type": "array"
+    },
+    "helm-values.app.driver.volumeWriteMode": {
+      "default": "in-place",
+      "description": "-- Controls how certificate data is written into pod volumes.\n`in-place` (default) rewrites existing files so consumer inotify\nwatches survive renewals. `atomic-dir` restores the upstream csi-lib timestamped-directory writer as a rollback path, and silently breaks raw-inotify consumers such as istio-agent on every renewal.",
+      "type": "string"
     },
     "helm-values.app.driver.volumes": {
       "default": [],

--- a/deploy/charts/csi-driver-athenz/values.schema.json
+++ b/deploy/charts/csi-driver-athenz/values.schema.json
@@ -506,8 +506,8 @@
       "type": "array"
     },
     "helm-values.app.driver.volumeWriteMode": {
-      "default": "in-place",
-      "description": "-- Controls how certificate data is written into pod volumes.\n`in-place` (default) rewrites existing files so consumer inotify\nwatches survive renewals. `atomic-dir` restores the upstream csi-lib timestamped-directory writer as a rollback path, and silently breaks raw-inotify consumers such as istio-agent on every renewal.",
+      "default": "atomic-dir",
+      "description": "-- Controls how certificate data is written into pod volumes.\n`atomic-dir` (default) is the upstream csi-lib timestamped-directory\nwriter; it silently breaks raw-inotify consumers such as istio-agent on every renewal, because replacing a file destroys the watched inode. `in-place` rewrites existing files instead, so those watches survive renewals.",
       "type": "string"
     },
     "helm-values.app.driver.volumes": {

--- a/deploy/charts/csi-driver-athenz/values.yaml
+++ b/deploy/charts/csi-driver-athenz/values.yaml
@@ -74,12 +74,12 @@ app:
       ca: ca.crt
 
     # -- Controls how certificate data is written into pod volumes.
-    # `in-place` (default) rewrites existing files so consumer inotify
-    # watches survive renewals. `atomic-dir` restores the upstream
-    # csi-lib timestamped-directory writer as a rollback path, and
-    # silently breaks raw-inotify consumers such as istio-agent on every
-    # renewal.
-    volumeWriteMode: in-place
+    # `atomic-dir` (default) is the upstream csi-lib timestamped-directory
+    # writer; it silently breaks raw-inotify consumers such as istio-agent
+    # on every renewal, because replacing a file destroys the watched
+    # inode. `in-place` rewrites existing files instead, so those watches
+    # survive renewals.
+    volumeWriteMode: atomic-dir
 
     # Opt-in provisioning of PKCS12 and JKS keystores alongside the PEM
     # identity files. When `enabled` is false (the default), no keystores

--- a/deploy/charts/csi-driver-athenz/values.yaml
+++ b/deploy/charts/csi-driver-athenz/values.yaml
@@ -73,6 +73,14 @@ app:
       # -- File name where the CA bundles are written to, if enabled.
       ca: ca.crt
 
+    # -- Controls how certificate data is written into pod volumes.
+    # `in-place` (default) rewrites existing files so consumer inotify
+    # watches survive renewals. `atomic-dir` restores the upstream
+    # csi-lib timestamped-directory writer as a rollback path, and
+    # silently breaks raw-inotify consumers such as istio-agent on every
+    # renewal.
+    volumeWriteMode: in-place
+
     # Opt-in provisioning of PKCS12 and JKS keystores alongside the PEM
     # identity files. When `enabled` is false (the default), no keystores
     # are written and the rest of the fields in this block have no effect.

--- a/internal/csi/app/app.go
+++ b/internal/csi/app/app.go
@@ -92,6 +92,7 @@ func NewCommand(ctx context.Context) *cobra.Command {
 				JKSFileName:         opts.Volume.JKSFileName,
 				KeystorePassword:    opts.Volume.KeystorePassword,
 				KeystoreAlias:       opts.Volume.KeystoreAlias,
+				WriteMode:           opts.Volume.WriteMode,
 
 				RootCAs: rootCA,
 

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -273,7 +273,10 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 			"renewal. `atomic-dir` restores the upstream csi-lib writer, which "+
 			"replaces the files via a new timestamped directory on every write "+
 			"and so silently breaks those watches; it is provided as a rollback "+
-			"path only.")
+			"path only. Note that `in-place` rewrites are not atomic against "+
+			"concurrent readers: a reader that catches the window between the "+
+			"write and the truncate must re-read on the next inotify event, as "+
+			"istio-agent does.")
 }
 
 func (o *Options) addAthenzFlags(fs *pflag.FlagSet) {

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -40,6 +40,21 @@ const DefaultKeystorePassword = "changeit"
 // leaking the password via `ps`.
 const KeystorePasswordEnvVar = "KEYSTORE_PASSWORD"
 
+// WriteModeInPlace and WriteModeAtomicDir are the accepted values of
+// --volume-write-mode. They mirror the driver package's constants of the same
+// name, duplicated here so flag parsing stays independent of the driver
+// package, as DefaultKeystorePassword already is.
+const (
+	// WriteModeInPlace rewrites the existing volume files so their inodes, and
+	// therefore the inotify watches consumers such as istio-agent hold on them,
+	// survive a certificate renewal.
+	WriteModeInPlace = "in-place"
+
+	// WriteModeAtomicDir restores the upstream csi-lib timestamped-directory
+	// writer. Rollback path only.
+	WriteModeAtomicDir = "atomic-dir"
+)
+
 // Options are the CSI Driver flag options.
 type Options struct {
 	*flags.Flags
@@ -139,6 +154,11 @@ type OptionsVolume struct {
 	// KeystoreAlias is the alias used for the private key entry inside the
 	// JKS keystore.
 	KeystoreAlias string
+
+	// WriteMode selects how certificate data is written into the Pod's volume.
+	// One of WriteModeInPlace (default) or WriteModeAtomicDir; validated during
+	// option completion.
+	WriteMode string
 }
 
 // OptionsAthenz is options specific to Athenz.
@@ -245,6 +265,15 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.Volume.KeystoreAlias, "keystore-alias", "service",
 		"Alias used for the private key entry inside the JKS keystore. "+
 			"Requires --enable-keystore.")
+
+	fs.StringVar(&o.Volume.WriteMode, "volume-write-mode", WriteModeInPlace,
+		"How certificate data is written into the pod's volume. `in-place` "+
+			"(default) rewrites the existing files, keeping their inodes so "+
+			"inotify watches held by consumers such as istio-agent survive a "+
+			"renewal. `atomic-dir` restores the upstream csi-lib writer, which "+
+			"replaces the files via a new timestamped directory on every write "+
+			"and so silently breaks those watches; it is provided as a rollback "+
+			"path only.")
 }
 
 func (o *Options) addAthenzFlags(fs *pflag.FlagSet) {
@@ -265,7 +294,23 @@ func (o *Options) Complete() error {
 	if err := o.Flags.Complete(); err != nil {
 		return err
 	}
+	if err := o.validateWriteMode(); err != nil {
+		return err
+	}
 	return o.loadKeystorePassword()
+}
+
+// validateWriteMode rejects an unrecognised --volume-write-mode at startup,
+// rather than letting the driver silently fall back to a write mode the
+// operator did not ask for.
+func (o *Options) validateWriteMode() error {
+	switch o.Volume.WriteMode {
+	case WriteModeInPlace, WriteModeAtomicDir:
+		return nil
+	default:
+		return fmt.Errorf("invalid --volume-write-mode %q, must be one of %q or %q",
+			o.Volume.WriteMode, WriteModeInPlace, WriteModeAtomicDir)
+	}
 }
 
 // loadKeystorePassword resolves Volume.KeystorePassword using the following

--- a/internal/csi/app/options/options.go
+++ b/internal/csi/app/options/options.go
@@ -50,8 +50,8 @@ const (
 	// survive a certificate renewal.
 	WriteModeInPlace = "in-place"
 
-	// WriteModeAtomicDir restores the upstream csi-lib timestamped-directory
-	// writer. Rollback path only.
+	// WriteModeAtomicDir is the upstream csi-lib timestamped-directory
+	// writer, and the default.
 	WriteModeAtomicDir = "atomic-dir"
 )
 
@@ -156,7 +156,7 @@ type OptionsVolume struct {
 	KeystoreAlias string
 
 	// WriteMode selects how certificate data is written into the Pod's volume.
-	// One of WriteModeInPlace (default) or WriteModeAtomicDir; validated during
+	// One of WriteModeAtomicDir (default) or WriteModeInPlace; validated during
 	// option completion.
 	WriteMode string
 }
@@ -266,17 +266,18 @@ func (o *Options) addVolumeFlags(fs *pflag.FlagSet) {
 		"Alias used for the private key entry inside the JKS keystore. "+
 			"Requires --enable-keystore.")
 
-	fs.StringVar(&o.Volume.WriteMode, "volume-write-mode", WriteModeInPlace,
-		"How certificate data is written into the pod's volume. `in-place` "+
-			"(default) rewrites the existing files, keeping their inodes so "+
-			"inotify watches held by consumers such as istio-agent survive a "+
-			"renewal. `atomic-dir` restores the upstream csi-lib writer, which "+
-			"replaces the files via a new timestamped directory on every write "+
-			"and so silently breaks those watches; it is provided as a rollback "+
-			"path only. Note that `in-place` rewrites are not atomic against "+
-			"concurrent readers: a reader that catches the window between the "+
-			"write and the truncate must re-read on the next inotify event, as "+
-			"istio-agent does.")
+	fs.StringVar(&o.Volume.WriteMode, "volume-write-mode", WriteModeAtomicDir,
+		"How certificate data is written into the pod's volume. `atomic-dir` "+
+			"(default) is the upstream csi-lib writer, which replaces the files "+
+			"via a new timestamped directory on every write; consumers that "+
+			"watch a file with raw inotify (istio-agent gateways with "+
+			"file-mounted certificates, for example) lose their watch on every "+
+			"renewal and keep serving the stale certificate. `in-place` "+
+			"rewrites the existing files instead, keeping their inodes so such "+
+			"watches survive renewals. Note that `in-place` rewrites are not "+
+			"atomic against concurrent readers: a reader that catches the "+
+			"window between the write and the truncate must re-read on the "+
+			"next inotify event, as istio-agent does.")
 }
 
 func (o *Options) addAthenzFlags(fs *pflag.FlagSet) {

--- a/internal/csi/app/options/options_test.go
+++ b/internal/csi/app/options/options_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 // Test_loadKeystorePassword_Precedence covers the resolution order:
-//   1. KEYSTORE_PASSWORD env var (when non-empty)
-//   2. --keystore-password-file contents
-//   3. built-in default "changeit"
+//  1. KEYSTORE_PASSWORD env var (when non-empty)
+//  2. --keystore-password-file contents
+//  3. built-in default "changeit"
 //
 // It also covers the disabled-feature short-circuit and the empty-file
 // fail-fast behaviour.
@@ -102,5 +102,30 @@ func Test_loadKeystorePassword_Precedence(t *testing.T) {
 		err := o.loadKeystorePassword()
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "reading --keystore-password-file")
+	})
+}
+
+// Test_validateWriteMode covers the accepted --volume-write-mode values and the
+// fail-fast on anything else, so a typo cannot silently leave the driver on a
+// write mode the operator did not ask for.
+func Test_validateWriteMode(t *testing.T) {
+	t.Run("in-place", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.WriteMode = WriteModeInPlace
+		require.NoError(t, o.validateWriteMode())
+	})
+
+	t.Run("atomic-dir", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.WriteMode = WriteModeAtomicDir
+		require.NoError(t, o.validateWriteMode())
+	})
+
+	t.Run("unknown-is-fatal", func(t *testing.T) {
+		o := &Options{}
+		o.Volume.WriteMode = "atomic"
+		err := o.validateWriteMode()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), `invalid --volume-write-mode "atomic"`)
 	})
 }

--- a/internal/csi/driver/camanager.go
+++ b/internal/csi/driver/camanager.go
@@ -47,6 +47,14 @@ type volumeStore interface {
 	WriteFiles(meta metadata.Metadata, files map[string][]byte) error
 }
 
+// singleFileWriter is implemented by stores that can update one file of a volume
+// without touching the others. *inplaceWriteStorage does; the csi-lib atomic
+// writer cannot, because it treats its payload as the complete desired contents
+// of the volume and deletes everything else.
+type singleFileWriter interface {
+	WriteFile(meta metadata.Metadata, name string, data []byte) error
+}
+
 // camanager is a process responsible for distributing trust bundles to
 // mounting pods.
 type camanager struct {
@@ -158,12 +166,46 @@ func (c *camanager) updateRootCAFiles() error {
 		return fmt.Errorf("failed to list managed volumes: %w", err)
 	}
 
+	// A store that can update a single file lets the trust bundle be published
+	// without reading or rewriting the certificate and key at all, which removes
+	// a race with certificate renewal: the full-payload path below reads the
+	// current keypair off the volume and writes that snapshot back alongside the
+	// new CA bundle, so a renewal landing between the read and the write is
+	// silently rolled back to the old pair while the renewal's metadata records
+	// success, and nothing retries until the next renewal. Writing only the CA
+	// file means the worst a concurrent renewal can do is write identical bytes
+	// to it.
+	singleFile, canWriteSingleFile := c.store.(singleFileWriter)
+
 	for _, volumeID := range volumeIDs {
 		meta, err := c.store.ReadMetadata(volumeID)
 		if err != nil {
 			return fmt.Errorf("%q: failed to read metadata from volume: %w", volumeID, err)
 		}
 
+		caPEM := c.rootCAs.CertificatesPEM()
+
+		// No need to re-write CA data again if it hasn't changed on file. A read
+		// error means the file cannot be confirmed to match, so write it.
+		caData, err := c.store.ReadFile(volumeID, c.caFileName)
+		if err == nil && bytes.Equal(caData, caPEM) {
+			continue
+		}
+
+		if canWriteSingleFile {
+			if err := singleFile.WriteFile(meta, c.caFileName, caPEM); err != nil {
+				return fmt.Errorf("%q: failed to write new ca data to volume: %w",
+					volumeID, err)
+			}
+
+			log.Info("updated CA file on volume", "volume", volumeID)
+			continue
+		}
+
+		// The atomic writer deletes every file that is not in its payload, so
+		// the certificate and key have to be read back and written again next to
+		// the CA bundle. This is the path with the renewal race described above;
+		// it only runs in the atomic-dir rollback mode.
 		certData, err := c.store.ReadFile(volumeID, c.certFileName)
 		if err != nil {
 			return fmt.Errorf("%q: failed to read certificate file from volume to perform write: %w",
@@ -175,16 +217,10 @@ func (c *camanager) updateRootCAFiles() error {
 				volumeID, err)
 		}
 
-		// No need to re-write CA data again if it hasn't changed on file.
-		caData, err := c.store.ReadFile(volumeID, c.caFileName)
-		if err == nil && bytes.Equal(caData, c.rootCAs.CertificatesPEM()) {
-			continue
-		}
-
 		if err := c.store.WriteFiles(meta, map[string][]byte{
 			c.certFileName: certData,
 			c.keyFileName:  keyData,
-			c.caFileName:   c.rootCAs.CertificatesPEM(),
+			c.caFileName:   caPEM,
 		}); err != nil {
 			return fmt.Errorf("%q: failed to write new ca data to volume: %w",
 				volumeID, err)

--- a/internal/csi/driver/camanager.go
+++ b/internal/csi/driver/camanager.go
@@ -205,7 +205,7 @@ func (c *camanager) updateRootCAFiles() error {
 		// The atomic writer deletes every file that is not in its payload, so
 		// the certificate and key have to be read back and written again next to
 		// the CA bundle. This is the path with the renewal race described above;
-		// it only runs in the atomic-dir rollback mode.
+		// it only runs in atomic-dir mode.
 		certData, err := c.store.ReadFile(volumeID, c.certFileName)
 		if err != nil {
 			return fmt.Errorf("%q: failed to read certificate file from volume to perform write: %w",

--- a/internal/csi/driver/camanager.go
+++ b/internal/csi/driver/camanager.go
@@ -22,12 +22,30 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/cert-manager/csi-lib/storage"
+	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/go-logr/logr"
 
 	"github.com/AthenZ/csi-driver-athenz/internal/csi/rootca"
 	"github.com/AthenZ/csi-driver-athenz/internal/version"
 )
+
+// volumeStore is the storage surface camanager needs: on top of the
+// storage.Interface methods it reads files back from mounted pod volumes, so it
+// cannot be satisfied by a metadata-only store. Both *storage.Filesystem and
+// *inplaceWriteStorage implement it.
+type volumeStore interface {
+	// ListVolumes returns the IDs of all volumes in the storage backend.
+	ListVolumes() ([]string, error)
+
+	// ReadMetadata reads the metadata for a single volume.
+	ReadMetadata(volumeID string) (metadata.Metadata, error)
+
+	// ReadFile reads the named file from the volume's data directory.
+	ReadFile(volumeID, name string) ([]byte, error)
+
+	// WriteFiles writes the given data into the volume's data directory.
+	WriteFiles(meta metadata.Metadata, files map[string][]byte) error
+}
 
 // camanager is a process responsible for distributing trust bundles to
 // mounting pods.
@@ -35,9 +53,9 @@ type camanager struct {
 	// log is the logger for camanager.
 	log logr.Logger
 
-	// store is the csi-lib file system storage implementation. Must by file
-	// system in order to read volumes back from mounted pods.
-	store *storage.Filesystem
+	// store must be able to read volumes back from mounted pods, and must be
+	// the same store the driver writes with so both use the same write mode.
+	store volumeStore
 
 	// rootCAs exposes the current trust bundle to be propagated, and signals
 	// when a new trust bundle is available.
@@ -55,7 +73,7 @@ type camanager struct {
 // newCAManager constructs a new camanager which distributes new trust bundles
 // to mounted pods, as they are changed.
 func newCAManager(log logr.Logger,
-	store *storage.Filesystem,
+	store volumeStore,
 	rootCAs rootca.Interface,
 	certFileName, keyFileName, caFileName string,
 ) *camanager {

--- a/internal/csi/driver/camanager_test.go
+++ b/internal/csi/driver/camanager_test.go
@@ -19,14 +19,46 @@ package driver
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/cert-manager/csi-lib/metadata"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2/klogr"
 
 	"github.com/AthenZ/csi-driver-athenz/internal/csi/rootca"
 )
+
+// updateDeadline is generous on purpose: the assertions here are about whether
+// run() dispatches an update at all, not about how quickly it does so, and a
+// tight deadline only produces flakes on a loaded CI machine.
+const updateDeadline = 5 * time.Second
+
+// fakeSubscribableRootCAs hands run() an event channel the test drives directly
+// and reports when run() has subscribed.
+//
+// rootca.NewMemory, which this test used to use, broadcasts only to the
+// subscribers that exist at the moment it receives a new bundle, and run()
+// subscribes from inside its own goroutine. An event published before that
+// subscription exists is silently dropped, and the test cannot observe when it
+// is safe to publish - which is the second half of this test's flakiness.
+type fakeSubscribableRootCAs struct {
+	events     chan struct{}
+	subscribed chan struct{}
+	once       sync.Once
+}
+
+func (f *fakeSubscribableRootCAs) CertificatesPEM() []byte { return nil }
+
+func (f *fakeSubscribableRootCAs) Subscribe() <-chan struct{} {
+	f.once.Do(func() { close(f.subscribed) })
+	return f.events
+}
+
+var _ rootca.Interface = &fakeSubscribableRootCAs{}
 
 func Test_manageCAFiles(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -34,55 +66,271 @@ func Test_manageCAFiles(t *testing.T) {
 		cancel()
 	})
 
-	t.Log("starting manageCAFiles()")
-	rootCAsChan := make(chan []byte)
+	rootCAs := &fakeSubscribableRootCAs{
+		events:     make(chan struct{}),
+		subscribed: make(chan struct{}),
+	}
 	c := &camanager{
 		log:     klogr.New(),
-		rootCAs: rootca.NewMemory(ctx, rootCAsChan),
+		rootCAs: rootCAs,
 	}
+
+	// updateRootCAFilesFn is installed once, before run() starts, and takes its
+	// behaviour from a channel. Reassigning the field after run() is already
+	// executing - as this test used to - is a data race on the field: run() reads
+	// it from its own goroutine.
+	behaviours := make(chan func() error, 4)
+	c.updateRootCAFilesFn = func() error {
+		select {
+		case behaviour := <-behaviours:
+			return behaviour()
+		case <-ctx.Done():
+			return nil
+		}
+	}
+
+	t.Log("starting manageCAFiles()")
 	go func() {
 		c.run(ctx, time.Millisecond*5)
 	}()
 
+	t.Log("waiting for run() to subscribe to root CA events")
+	select {
+	case <-rootCAs.subscribed:
+	case <-time.After(updateDeadline):
+		t.Fatal("run() never subscribed to root CA events")
+	}
+
 	t.Log("if root CAs update happens, expect updateRootCAFilesFn() to be called")
-	calledCtx, calledCancel := context.WithCancel(context.TODO())
-	c.updateRootCAFilesFn = func() error {
+	calledChan := make(chan struct{})
+	behaviours <- func() error {
 		t.Log("updateRootCAFilesFn() called")
-		calledCancel()
+		close(calledChan)
 		return nil
 	}
 
-	t.Log("sending event to rootCAsChan")
-	rootCAsChan <- []byte("root cas")
-	t.Log("waiting to for calledCtx to be closed")
+	t.Log("sending root CAs event")
+	rootCAs.events <- struct{}{}
+	t.Log("waiting for the call")
 	select {
-	case <-calledCtx.Done():
+	case <-calledChan:
 		break
-	case <-time.After(time.Millisecond * 500):
+	case <-time.After(updateDeadline):
 		assert.Fail(t, "updateRootCAFilesFn() was not called in time")
 	}
 
 	t.Log("should call updateRootCAFilesFn() again if it fails")
-	var i int
 	calledTwiceChan := make(chan struct{})
-	c.updateRootCAFilesFn = func() error {
-		if i == 0 {
-			i++
-			t.Log("returning error from updateRootCAFilesFn()")
-			return errors.New("this is an error")
-		}
+	behaviours <- func() error {
+		t.Log("returning error from updateRootCAFilesFn()")
+		return errors.New("this is an error")
+	}
+	behaviours <- func() error {
 		t.Log("returning nil from updateRootCAFilesFn()")
 		close(calledTwiceChan)
 		return nil
 	}
 
-	t.Log("sending another root CAs update")
-	rootCAsChan <- []byte("another root cas")
+	t.Log("sending another root CAs event")
+	rootCAs.events <- struct{}{}
 	t.Log("waiting for two calls")
 	select {
 	case <-calledTwiceChan:
 		break
-	case <-time.After(time.Millisecond * 500):
+	case <-time.After(updateDeadline):
 		assert.Fail(t, "updateRootCAFilesFn() was not called twice in time")
 	}
+}
+
+// fakeRootCAs is a fixed trust bundle. rootca.NewMemory would do, but its
+// contents are only set asynchronously from a channel.
+type fakeRootCAs struct {
+	pem []byte
+}
+
+func (f *fakeRootCAs) CertificatesPEM() []byte    { return f.pem }
+func (f *fakeRootCAs) Subscribe() <-chan struct{} { return make(chan struct{}) }
+
+var _ rootca.Interface = &fakeRootCAs{}
+
+// fakeCAStore implements the atomic-dir surface: only whole-payload writes, with
+// the atomic writer's desired-state semantics.
+type fakeCAStore struct {
+	volumeIDs []string
+	files     map[string]map[string][]byte
+
+	// writeFilesPayloads records every whole-volume write.
+	writeFilesPayloads []map[string][]byte
+}
+
+func newFakeCAStore(volumeID string, files map[string][]byte) *fakeCAStore {
+	return &fakeCAStore{
+		volumeIDs: []string{volumeID},
+		files:     map[string]map[string][]byte{volumeID: files},
+	}
+}
+
+func (f *fakeCAStore) ListVolumes() ([]string, error) { return f.volumeIDs, nil }
+
+func (f *fakeCAStore) ReadMetadata(volumeID string) (metadata.Metadata, error) {
+	return metadata.Metadata{VolumeID: volumeID}, nil
+}
+
+func (f *fakeCAStore) ReadFile(volumeID, name string) ([]byte, error) {
+	data, ok := f.files[volumeID][name]
+	if !ok {
+		return nil, fmt.Errorf("no such file %q on volume %q", name, volumeID)
+	}
+	return data, nil
+}
+
+func (f *fakeCAStore) WriteFiles(meta metadata.Metadata, files map[string][]byte) error {
+	f.writeFilesPayloads = append(f.writeFilesPayloads, files)
+
+	// The atomic writer treats the payload as the complete desired contents of
+	// the volume and deletes everything else.
+	replaced := map[string][]byte{}
+	for name, data := range files {
+		replaced[name] = data
+	}
+	f.files[meta.VolumeID] = replaced
+
+	return nil
+}
+
+var _ volumeStore = &fakeCAStore{}
+
+// fakeSingleFileCAStore adds the single-file write the in-place store provides.
+type fakeSingleFileCAStore struct {
+	*fakeCAStore
+
+	// singleWrites records every CA-only write, in order.
+	singleWrites []fakeSingleWrite
+}
+
+type fakeSingleWrite struct {
+	volumeID string
+	name     string
+	data     []byte
+}
+
+func (f *fakeSingleFileCAStore) WriteFile(meta metadata.Metadata, name string, data []byte) error {
+	f.singleWrites = append(f.singleWrites, fakeSingleWrite{meta.VolumeID, name, data})
+	f.files[meta.VolumeID][name] = data
+
+	return nil
+}
+
+var (
+	_ volumeStore      = &fakeSingleFileCAStore{}
+	_ singleFileWriter = &fakeSingleFileCAStore{}
+)
+
+func newTestCAManager(store volumeStore, caPEM string) *camanager {
+	return &camanager{
+		log:          klogr.New(),
+		store:        store,
+		rootCAs:      &fakeRootCAs{pem: []byte(caPEM)},
+		certFileName: "tls.crt",
+		keyFileName:  "tls.key",
+		caFileName:   "ca.crt",
+	}
+}
+
+// In in-place mode the trust bundle is published on its own. Rewriting the
+// certificate and key from a snapshot read moments earlier silently rolls back a
+// renewal that landed in between, while the renewal's metadata records success.
+func Test_updateRootCAFiles_inPlaceWritesOnlyTheCAFile(t *testing.T) {
+	inner := newFakeCAStore("vol-id", map[string][]byte{
+		"tls.crt": []byte("cert-1"),
+		"tls.key": []byte("key-1"),
+		"ca.crt":  []byte("ca-old"),
+	})
+	store := &fakeSingleFileCAStore{fakeCAStore: inner}
+
+	require.NoError(t, newTestCAManager(store, "ca-new").updateRootCAFiles())
+
+	assert.Empty(t, inner.writeFilesPayloads,
+		"a store that can write a single file must never take the whole-payload path: reading "+
+			"the keypair and writing it back races with certificate renewal")
+
+	require.Len(t, store.singleWrites, 1)
+	assert.Equal(t, fakeSingleWrite{"vol-id", "ca.crt", []byte("ca-new")}, store.singleWrites[0])
+
+	assert.Equal(t, []byte("cert-1"), inner.files["vol-id"]["tls.crt"],
+		"the certificate must not be touched by a trust bundle update")
+	assert.Equal(t, []byte("key-1"), inner.files["vol-id"]["tls.key"],
+		"the private key must not be touched by a trust bundle update")
+}
+
+// The certificate and key are not read at all in in-place mode, so a volume
+// whose keypair cannot be read still gets its trust bundle updated.
+func Test_updateRootCAFiles_inPlaceDoesNotReadTheKeypair(t *testing.T) {
+	inner := newFakeCAStore("vol-id", map[string][]byte{"ca.crt": []byte("ca-old")})
+	store := &fakeSingleFileCAStore{fakeCAStore: inner}
+
+	require.NoError(t, newTestCAManager(store, "ca-new").updateRootCAFiles())
+
+	require.Len(t, store.singleWrites, 1)
+	assert.Equal(t, []byte("ca-new"), inner.files["vol-id"]["ca.crt"])
+}
+
+func Test_updateRootCAFiles_skipsUnchangedCAData(t *testing.T) {
+	t.Run("in-place", func(t *testing.T) {
+		inner := newFakeCAStore("vol-id", map[string][]byte{
+			"tls.crt": []byte("cert-1"),
+			"tls.key": []byte("key-1"),
+			"ca.crt":  []byte("ca-same"),
+		})
+		store := &fakeSingleFileCAStore{fakeCAStore: inner}
+
+		require.NoError(t, newTestCAManager(store, "ca-same").updateRootCAFiles())
+
+		assert.Empty(t, store.singleWrites, "an unchanged trust bundle must not be rewritten")
+		assert.Empty(t, inner.writeFilesPayloads)
+	})
+
+	t.Run("atomic-dir", func(t *testing.T) {
+		store := newFakeCAStore("vol-id", map[string][]byte{
+			"tls.crt": []byte("cert-1"),
+			"tls.key": []byte("key-1"),
+			"ca.crt":  []byte("ca-same"),
+		})
+
+		require.NoError(t, newTestCAManager(store, "ca-same").updateRootCAFiles())
+
+		assert.Empty(t, store.writeFilesPayloads, "an unchanged trust bundle must not be rewritten")
+	})
+}
+
+// The atomic-dir rollback keeps the original behaviour: the atomic writer
+// deletes every file missing from its payload, so all three have to be written.
+func Test_updateRootCAFiles_atomicDirWritesAllThreeFiles(t *testing.T) {
+	store := newFakeCAStore("vol-id", map[string][]byte{
+		"tls.crt": []byte("cert-1"),
+		"tls.key": []byte("key-1"),
+		"ca.crt":  []byte("ca-old"),
+	})
+
+	require.NoError(t, newTestCAManager(store, "ca-new").updateRootCAFiles())
+
+	require.Len(t, store.writeFilesPayloads, 1)
+	assert.Equal(t, map[string][]byte{
+		"tls.crt": []byte("cert-1"),
+		"tls.key": []byte("key-1"),
+		"ca.crt":  []byte("ca-new"),
+	}, store.writeFilesPayloads[0],
+		"the atomic writer prunes anything missing from its payload, so the keypair has to be "+
+			"written back alongside the new trust bundle")
+}
+
+// Without a single-file writer the keypair has to be readable, and a volume that
+// has not been written yet must surface an error rather than publish a partial
+// payload the atomic writer would prune the rest of.
+func Test_updateRootCAFiles_atomicDirErrorsWhenKeypairIsUnreadable(t *testing.T) {
+	store := newFakeCAStore("vol-id", map[string][]byte{"ca.crt": []byte("ca-old")})
+
+	err := newTestCAManager(store, "ca-new").updateRootCAFiles()
+	require.Error(t, err)
+	assert.Empty(t, store.writeFilesPayloads)
 }

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -331,8 +331,9 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		d.store = inplace
 		caStore = inplace
 	case WriteModeAtomicDir:
-		d.store = store
-		caStore = store
+		atomicDir := newAtomicDirStorage(store)
+		d.store = atomicDir
+		caStore = atomicDir
 	default:
 		return nil, fmt.Errorf("invalid volume write mode %q, must be one of %q or %q",
 			opts.WriteMode, WriteModeInPlace, WriteModeAtomicDir)

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -137,10 +137,10 @@ type Options struct {
 	KeystoreAlias string
 
 	// WriteMode selects how certificate data is written into the Pod's volume.
-	// WriteModeInPlace (the default when empty) rewrites the existing files so
-	// their inodes - and therefore the inotify watches consumers hold on them -
-	// survive a renewal. WriteModeAtomicDir restores the upstream csi-lib
-	// timestamped-directory writer and exists only as a rollback path.
+	// WriteModeAtomicDir (the default when empty) is the upstream csi-lib
+	// timestamped-directory writer. WriteModeInPlace rewrites the existing
+	// files instead, so their inodes - and therefore the inotify watches
+	// consumers hold on them - survive a renewal.
 	WriteMode string
 
 	// RestConfig is used for interacting with the Kubernetes API server.
@@ -326,11 +326,11 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 	// `..data` layout on a CA bundle update and break every live watch again.
 	var caStore volumeStore
 	switch opts.WriteMode {
-	case "", WriteModeInPlace:
+	case WriteModeInPlace:
 		inplace := newInplaceWriteStorage(store, d.certFileName)
 		d.store = inplace
 		caStore = inplace
-	case WriteModeAtomicDir:
+	case "", WriteModeAtomicDir:
 		atomicDir := newAtomicDirStorage(store)
 		d.store = atomicDir
 		caStore = atomicDir

--- a/internal/csi/driver/driver.go
+++ b/internal/csi/driver/driver.go
@@ -136,6 +136,13 @@ type Options struct {
 	// JKS keystore. Defaults to DefaultKeystoreAlias if empty.
 	KeystoreAlias string
 
+	// WriteMode selects how certificate data is written into the Pod's volume.
+	// WriteModeInPlace (the default when empty) rewrites the existing files so
+	// their inodes - and therefore the inotify watches consumers hold on them -
+	// survive a renewal. WriteModeAtomicDir restores the upstream csi-lib
+	// timestamped-directory writer and exists only as a rollback path.
+	WriteMode string
+
 	// RestConfig is used for interacting with the Kubernetes API server.
 	RestConfig *rest.Config
 
@@ -310,11 +317,28 @@ func New(ctx context.Context, log logr.Logger, opts Options) (*Driver, error) {
 		return nil, fmt.Errorf("failed to setup filesystem: %w", err)
 	}
 	// Used by clients to set the stored file's file-system group before
-	// mounting.
+	// mounting. Must be set before the store is wrapped below, since the
+	// in-place writer copies the key at construction.
 	store.FSGroupVolumeAttributeKey = "csi.cert-manager.athenz.io/fs-group"
 
-	d.store = store
-	d.camanager = newCAManager(log, store, opts.RootCAs,
+	// The CA manager writes to the same volumes as the driver, so it has to use
+	// the same writer: if it kept the atomic writer it would recreate the
+	// `..data` layout on a CA bundle update and break every live watch again.
+	var caStore volumeStore
+	switch opts.WriteMode {
+	case "", WriteModeInPlace:
+		inplace := newInplaceWriteStorage(store, d.certFileName)
+		d.store = inplace
+		caStore = inplace
+	case WriteModeAtomicDir:
+		d.store = store
+		caStore = store
+	default:
+		return nil, fmt.Errorf("invalid volume write mode %q, must be one of %q or %q",
+			opts.WriteMode, WriteModeInPlace, WriteModeAtomicDir)
+	}
+
+	d.camanager = newCAManager(log, caStore, opts.RootCAs,
 		d.certFileName, d.keyFileName, d.caFileName)
 
 	cmclient, err := cmclient.NewForConfig(opts.RestConfig)

--- a/internal/csi/driver/storage_inplace.go
+++ b/internal/csi/driver/storage_inplace.go
@@ -1,0 +1,360 @@
+/*
+Copyright The Athenz Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+)
+
+const (
+	// WriteModeInPlace rewrites the contents of the existing files in the
+	// volume's data directory, never replacing the files themselves. Consumers
+	// such as istio-agent watch the certificate file with raw inotify, which
+	// binds to the file's inode: replacing the file (as the csi-lib atomic
+	// writer does, and as a temp-file + rename would too) unlinks that inode,
+	// the kernel tears the watch down, and the consumer keeps serving a stale
+	// certificate until it expires.
+	WriteModeInPlace = "in-place"
+
+	// WriteModeAtomicDir is the upstream csi-lib behaviour: every write creates
+	// a new timestamped directory, re-points the `..data` symlink and deletes
+	// the previous directory. Kept only as a rollback path.
+	WriteModeAtomicDir = "atomic-dir"
+)
+
+const (
+	// inplaceDataDirMode matches the data directory mode used by csi-lib: read
+	// and execute only for the fs user and group.
+	inplaceDataDirMode os.FileMode = 0550
+
+	// inplaceDataFileMode matches the file mode used by csi-lib for projected
+	// certificate data: read only for the owner and group.
+	inplaceDataFileMode os.FileMode = 0440
+)
+
+// innerStore is the subset of the csi-lib file system storage that
+// inplaceWriteStorage delegates to. *storage.Filesystem satisfies it. It is an
+// interface rather than the concrete type so the writer can be unit tested:
+// storage.NewFilesystem mounts a tmpfs and the fields needed to build a
+// *storage.Filesystem by hand are unexported.
+type innerStore interface {
+	storage.Interface
+
+	// ReadFile is not part of storage.Interface but is required by camanager.
+	ReadFile(volumeID, name string) ([]byte, error)
+}
+
+// inplaceWriteStorage decorates the csi-lib file system storage, replacing its
+// atomic (timestamped directory) writer with one that rewrites file contents in
+// place. Every other operation is delegated untouched.
+type inplaceWriteStorage struct {
+	inner innerStore
+
+	// certFileName is the name of the certificate file, which is written last.
+	certFileName string
+
+	// fsGroupVolumeAttributeKey mirrors Filesystem.FSGroupVolumeAttributeKey.
+	// It is copied at construction, so the inner store's key must already be
+	// set when the wrapper is built.
+	fsGroupVolumeAttributeKey string
+}
+
+var _ storage.Interface = &inplaceWriteStorage{}
+
+// newInplaceWriteStorage wraps inner so that certificate data is rewritten in
+// place instead of through csi-lib's atomic writer.
+func newInplaceWriteStorage(inner *storage.Filesystem, certFileName string) *inplaceWriteStorage {
+	return &inplaceWriteStorage{
+		inner:                     inner,
+		certFileName:              certFileName,
+		fsGroupVolumeAttributeKey: inner.FSGroupVolumeAttributeKey,
+	}
+}
+
+func (s *inplaceWriteStorage) PathForVolume(volumeID string) string {
+	return s.inner.PathForVolume(volumeID)
+}
+
+func (s *inplaceWriteStorage) RemoveVolume(volumeID string) error {
+	return s.inner.RemoveVolume(volumeID)
+}
+
+func (s *inplaceWriteStorage) ReadMetadata(volumeID string) (metadata.Metadata, error) {
+	return s.inner.ReadMetadata(volumeID)
+}
+
+func (s *inplaceWriteStorage) ListVolumes() ([]string, error) {
+	return s.inner.ListVolumes()
+}
+
+func (s *inplaceWriteStorage) WriteMetadata(volumeID string, meta metadata.Metadata) error {
+	return s.inner.WriteMetadata(volumeID, meta)
+}
+
+func (s *inplaceWriteStorage) RegisterMetadata(meta metadata.Metadata) (bool, error) {
+	return s.inner.RegisterMetadata(meta)
+}
+
+func (s *inplaceWriteStorage) ReadFile(volumeID, name string) ([]byte, error) {
+	return s.inner.ReadFile(volumeID, name)
+}
+
+// WriteFiles writes the given data into the volume's data directory, rewriting
+// the contents of any file that already exists rather than replacing it.
+//
+// Nothing in this path deletes, renames or symlinks: the inode a mounted pod
+// has open (and has an inotify watch on) must survive every write. When the
+// volume was previously written by the csi-lib atomic writer the data directory
+// still holds the `..data` symlink layout; opening `<data>/tls.crt` follows that
+// chain and rewrites the file inside the timestamped directory, which is exactly
+// what we want - the layout is left alone and live pods keep working.
+func (s *inplaceWriteStorage) WriteFiles(meta metadata.Metadata, files map[string][]byte) error {
+	dataPath := s.inner.PathForVolume(meta.VolumeID)
+	if err := os.MkdirAll(dataPath, inplaceDataDirMode); err != nil {
+		return fmt.Errorf("ensuring data directory %q: %w", dataPath, err)
+	}
+
+	fsGroup, err := s.fsGroupForMetadata(meta)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureDataDirGroup(dataPath, fsGroup); err != nil {
+		return err
+	}
+
+	// A half-torn-down atomic-writer layout (a `..data` chain pointing at a
+	// timestamped directory that no longer exists) can never be repaired by
+	// writing through it. Any watch on the old inodes is already dead at that
+	// point, so rebuilding the layout with the inner atomic writer cannot break
+	// a live consumer - and it is the only way to make the volume writable
+	// again.
+	broken, err := anyDanglingSymlink(dataPath, files)
+	if err != nil {
+		return err
+	}
+	if broken {
+		return s.inner.WriteFiles(meta, files)
+	}
+
+	for _, name := range orderedWriteNames(files, s.certFileName) {
+		if err := writeFileInPlace(filepath.Join(dataPath, name), files[name], fsGroup); err != nil {
+			return fmt.Errorf("writing file %q: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+// orderedWriteNames returns the file names to write, all names sorted
+// alphabetically followed by certFileName.
+//
+// The order is part of the contract with the consumer: istio-agent watches only
+// the certificate file, assuming the private key cannot change without the
+// certificate changing too. Writing the certificate last means the single event
+// it does receive fires when the key, CA bundle and keystores on disk are
+// already the matching set.
+func orderedWriteNames(files map[string][]byte, certFileName string) []string {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		if name == certFileName {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if _, ok := files[certFileName]; ok {
+		names = append(names, certFileName)
+	}
+
+	return names
+}
+
+// anyDanglingSymlink reports whether any of the files about to be written
+// currently exists as a symlink whose chain no longer resolves to a real file.
+func anyDanglingSymlink(dataPath string, files map[string][]byte) (bool, error) {
+	for name := range files {
+		target := filepath.Join(dataPath, name)
+
+		info, err := os.Lstat(target)
+		if errors.Is(err, os.ErrNotExist) {
+			// Nothing there yet: a plain create, not a broken chain.
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("checking %q for a dangling symlink: %w", name, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		} else if err != nil {
+			return false, fmt.Errorf("resolving symlink %q: %w", name, err)
+		}
+	}
+
+	return false, nil
+}
+
+// writeFileInPlace overwrites the contents of target, following any symlink
+// chain, without ever unlinking the file the pod is reading.
+func writeFileInPlace(target string, data []byte, fsGroup *int64) error {
+	// Lstat before opening so we can tell a file we are creating from one that
+	// already exists. Only a freshly created file needs its mode and group
+	// ownership set: re-applying them on every write is pure metadata churn
+	// that wakes every watcher with an IN_ATTRIB event for no reason.
+	_, err := os.Lstat(target)
+	created := errors.Is(err, os.ErrNotExist)
+	if err != nil && !created {
+		return fmt.Errorf("checking existing file: %w", err)
+	}
+
+	// Skip identical content, as the csi-lib atomic writer does. camanager
+	// rewrites every file on each trust-bundle update even when nothing
+	// changed; rewriting the same bytes would wake the pod's watcher for a
+	// no-op reload. A read error simply falls through to the write, which will
+	// surface the real problem.
+	if !created {
+		if existing, err := os.ReadFile(target); err == nil && bytes.Equal(existing, data) {
+			return nil
+		}
+	}
+
+	// No O_TRUNC: truncating first would briefly expose a zero-length file to
+	// readers. No O_NOFOLLOW: following an existing symlink chain is deliberate.
+	f, openErr := os.OpenFile(target, os.O_WRONLY|os.O_CREATE, inplaceDataFileMode)
+	if openErr != nil {
+		return fmt.Errorf("opening file for writing: %w", openErr)
+	}
+
+	if err := writeContentsInPlace(f, data, created, fsGroup); err != nil {
+		// Close is best effort here; the write error is the interesting one.
+		f.Close()
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing file: %w", err)
+	}
+
+	return nil
+}
+
+// writeContentsInPlace performs the write on an already open file. The caller
+// owns closing f.
+func writeContentsInPlace(f *os.File, data []byte, created bool, fsGroup *int64) error {
+	if _, err := f.WriteAt(data, 0); err != nil {
+		return fmt.Errorf("writing contents: %w", err)
+	}
+
+	// Drop anything left over from a longer previous version of the file. This
+	// happens after the write so readers never observe a short file.
+	if err := f.Truncate(int64(len(data))); err != nil {
+		return fmt.Errorf("truncating to written length: %w", err)
+	}
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("syncing contents: %w", err)
+	}
+
+	if !created {
+		return nil
+	}
+
+	if err := f.Chmod(inplaceDataFileMode); err != nil {
+		return fmt.Errorf("setting file mode: %w", err)
+	}
+
+	if fsGroup != nil {
+		// -1 for the uid means "do not change the owner".
+		if err := f.Chown(-1, int(*fsGroup)); err != nil {
+			return fmt.Errorf("setting file gid to %d: %w", *fsGroup, err)
+		}
+	}
+
+	return nil
+}
+
+// ensureDataDirGroup chowns the data directory to fsGroup, but only if it is
+// not already owned by that group. csi-lib chowns unconditionally on every
+// write, which is what produced a misleading IN_ATTRIB event while the stale
+// certificate incident was being diagnosed.
+func ensureDataDirGroup(dataPath string, fsGroup *int64) error {
+	if fsGroup == nil {
+		return nil
+	}
+
+	info, err := os.Stat(dataPath)
+	if err != nil {
+		return fmt.Errorf("stat data directory %q: %w", dataPath, err)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int64(stat.Gid) == *fsGroup {
+		return nil
+	}
+
+	if err := os.Chown(dataPath, -1, int(*fsGroup)); err != nil {
+		return fmt.Errorf("failed to chown data dir to gid %v: %w", *fsGroup, err)
+	}
+
+	return nil
+}
+
+// fsGroupForMetadata returns the gid that file and data directory ownership
+// should be set to, or nil if ownership should be left alone. It mirrors the
+// resolution csi-lib's Filesystem performs, which is unexported there.
+func (s *inplaceWriteStorage) fsGroupForMetadata(meta metadata.Metadata) (*int64, error) {
+	// The volume attribute takes precedence over the VolumeMountGroup set via
+	// securityContext.fsGroup, so ownership can be controlled per volume.
+	fsGroupStr := ""
+	if len(s.fsGroupVolumeAttributeKey) > 0 {
+		fsGroupStr = meta.VolumeContext[s.fsGroupVolumeAttributeKey]
+	}
+	if fsGroupStr == "" {
+		fsGroupStr = meta.VolumeMountGroup
+	}
+	if fsGroupStr == "" {
+		return nil, nil
+	}
+
+	fsGroup, err := strconv.ParseInt(fsGroupStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q, value must be a valid integer: %w",
+			s.fsGroupVolumeAttributeKey, err)
+	}
+
+	// 4294967295 is the largest gid on most modern operating systems. A smaller
+	// real maximum will simply fail later during the chown.
+	if fsGroup <= 0 || fsGroup > 4294967295 {
+		return nil, fmt.Errorf("%q: gid value must be greater than 0 and less than 4294967295: %d",
+			s.fsGroupVolumeAttributeKey, fsGroup)
+	}
+
+	return &fsGroup, nil
+}

--- a/internal/csi/driver/storage_inplace.go
+++ b/internal/csi/driver/storage_inplace.go
@@ -42,9 +42,9 @@ const (
 	// certificate until it expires.
 	WriteModeInPlace = "in-place"
 
-	// WriteModeAtomicDir is the upstream csi-lib behaviour: every write creates
-	// a new timestamped directory, re-points the `..data` symlink and deletes
-	// the previous directory. Kept only as a rollback path.
+	// WriteModeAtomicDir is the upstream csi-lib behaviour and the default:
+	// every write creates a new timestamped directory, re-points the `..data`
+	// symlink and deletes the previous directory.
 	WriteModeAtomicDir = "atomic-dir"
 )
 

--- a/internal/csi/driver/storage_inplace.go
+++ b/internal/csi/driver/storage_inplace.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/cert-manager/csi-lib/metadata"
@@ -54,6 +56,24 @@ const (
 	// inplaceDataFileMode matches the file mode used by csi-lib for projected
 	// certificate data: read only for the owner and group.
 	inplaceDataFileMode os.FileMode = 0440
+
+	// atomicDataDirName is the name of the symlink the csi-lib atomic writer
+	// points at the current timestamped directory. Kept in sync with
+	// third_party/util.dataDirName, which is unexported there.
+	atomicDataDirName = "..data"
+
+	// atomicReservedPrefix is the prefix the atomic writer reserves for its own
+	// bookkeeping entries (`..data` and the timestamped directories). Payload
+	// names may not start with it, so any entry that does belongs to the writer.
+	atomicReservedPrefix = ".."
+)
+
+const (
+	// inplaceMaxFileNameLength and inplaceMaxPathLength mirror
+	// maxFileNameLength and maxPathLength in csi-lib's vendored copy of the
+	// Kubernetes atomic writer, which are unexported there.
+	inplaceMaxFileNameLength = 255
+	inplaceMaxPathLength     = 4096
 )
 
 // innerStore is the subset of the csi-lib file system storage that
@@ -83,7 +103,12 @@ type inplaceWriteStorage struct {
 	fsGroupVolumeAttributeKey string
 }
 
-var _ storage.Interface = &inplaceWriteStorage{}
+var (
+	_ storage.Interface = &inplaceWriteStorage{}
+
+	// camanager detects the CA-only write path through this interface.
+	_ singleFileWriter = &inplaceWriteStorage{}
+)
 
 // newInplaceWriteStorage wraps inner so that certificate data is rewritten in
 // place instead of through csi-lib's atomic writer.
@@ -126,14 +151,26 @@ func (s *inplaceWriteStorage) ReadFile(volumeID, name string) ([]byte, error) {
 // WriteFiles writes the given data into the volume's data directory, rewriting
 // the contents of any file that already exists rather than replacing it.
 //
-// Nothing in this path deletes, renames or symlinks: the inode a mounted pod
-// has open (and has an inotify watch on) must survive every write. When the
-// volume was previously written by the csi-lib atomic writer the data directory
-// still holds the `..data` symlink layout; opening `<data>/tls.crt` follows that
-// chain and rewrites the file inside the timestamped directory, which is exactly
-// what we want - the layout is left alone and live pods keep working.
+// As upstream, the payload is the complete desired contents of the volume: any
+// other file in the root of the data directory is removed. Beyond that nothing
+// in this path deletes, renames or symlinks: the inode a mounted pod has open
+// (and has an inotify watch on) must survive every write. When the volume was
+// previously written by the csi-lib atomic writer the data directory still holds
+// the `..data` symlink layout; opening `<data>/tls.crt` follows that chain and
+// rewrites the file inside the timestamped directory, which is exactly what we
+// want - the layout is left alone and live pods keep working.
 func (s *inplaceWriteStorage) WriteFiles(meta metadata.Metadata, files map[string][]byte) error {
+	if err := validatePayloadNames(files); err != nil {
+		return err
+	}
+
 	dataPath := s.inner.PathForVolume(meta.VolumeID)
+
+	// Only the data directory is created here, where csi-lib's
+	// ensureVolumeDirectory also creates the volume directory holding
+	// metadata.json. That is safe: RegisterMetadata creates the volume directory
+	// when the volume is first published, and no write can reach this method for
+	// a volume the driver has no metadata for.
 	if err := os.MkdirAll(dataPath, inplaceDataDirMode); err != nil {
 		return fmt.Errorf("ensuring data directory %q: %w", dataPath, err)
 	}
@@ -147,24 +184,342 @@ func (s *inplaceWriteStorage) WriteFiles(meta metadata.Metadata, files map[strin
 		return err
 	}
 
-	// A half-torn-down atomic-writer layout (a `..data` chain pointing at a
-	// timestamped directory that no longer exists) can never be repaired by
-	// writing through it. Any watch on the old inodes is already dead at that
-	// point, so rebuilding the layout with the inner atomic writer cannot break
-	// a live consumer - and it is the only way to make the volume writable
-	// again.
-	broken, err := anyDanglingSymlink(dataPath, files)
+	// A symlink layout whose target directory is gone can never be repaired by
+	// writing through it: opening any file in it fails with ENOENT. Both shapes
+	// brokenAtomicLayout recognises imply the file the symlink resolved to has
+	// been deleted, so every watch that went through it is already dead, and
+	// rebuilding the layout with the inner atomic writer cannot break a live
+	// consumer. It is also the only way to make the volume writable again.
+	broken, err := brokenAtomicLayout(dataPath, files)
 	if err != nil {
 		return err
 	}
 	if broken {
+		if err := clearInplaceArtifacts(dataPath); err != nil {
+			return err
+		}
 		return s.inner.WriteFiles(meta, files)
+	}
+
+	if err := removeUnlistedFiles(dataPath, files); err != nil {
+		return err
 	}
 
 	for _, name := range orderedWriteNames(files, s.certFileName) {
 		if err := writeFileInPlace(filepath.Join(dataPath, name), files[name], fsGroup); err != nil {
 			return fmt.Errorf("writing file %q: %w", name, err)
 		}
+	}
+
+	return nil
+}
+
+// WriteFile updates a single file in the volume's data directory in place,
+// leaving every other file alone.
+//
+// camanager publishes trust bundle updates through this method. The alternative
+// - reading the current certificate and key off the volume and writing them
+// back alongside the new CA bundle, which the atomic writer's desired-state
+// payload forces it to do - silently rolls back a renewal that lands between
+// that read and the write: the old keypair is written over the new one while the
+// renewal's metadata records success, and nothing retries until the next
+// renewal. Touching only the CA file removes the race; the worst a concurrent
+// renewal can do is write identical bytes to it.
+func (s *inplaceWriteStorage) WriteFile(meta metadata.Metadata, name string, data []byte) error {
+	if err := validatePayloadName(name); err != nil {
+		return err
+	}
+
+	dataPath := s.inner.PathForVolume(meta.VolumeID)
+
+	// See WriteFiles for why only the data directory is ensured here.
+	if err := os.MkdirAll(dataPath, inplaceDataDirMode); err != nil {
+		return fmt.Errorf("ensuring data directory %q: %w", dataPath, err)
+	}
+
+	fsGroup, err := s.fsGroupForMetadata(meta)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureDataDirGroup(dataPath, fsGroup); err != nil {
+		return err
+	}
+
+	// Unlike WriteFiles this must not fall back to the inner atomic writer: that
+	// writer treats its payload as the complete desired state, so handing it a
+	// single-file payload would delete every other file in the volume. Failing
+	// is the safe answer - the pod's watches on a broken layout are already
+	// dead, and the next full renewal or re-publish rebuilds the volume.
+	broken, err := brokenAtomicLayout(dataPath, map[string][]byte{name: data})
+	if err != nil {
+		return err
+	}
+	if broken {
+		return fmt.Errorf("cannot write %q in place: the `..data` symlink layout of volume %q is broken; "+
+			"the next full write will rebuild it", name, meta.VolumeID)
+	}
+
+	if err := writeFileInPlace(filepath.Join(dataPath, name), data, fsGroup); err != nil {
+		return fmt.Errorf("writing file %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// atomicDirStorage is a thin decorator over the csi-lib file system storage that
+// clears the in-place writer's leftovers before every atomic write.
+//
+// It is what makes `--volume-write-mode=atomic-dir` an actually usable rollback
+// once the in-place writer has run on a node. The atomic writer cannot put a
+// user-visible symlink over an existing regular file and does not notice that it
+// failed to (see clearInplaceArtifacts); without this wrapper the rollback keeps
+// reporting success while silently delivering no renewals at all, which is worse
+// than the broken inotify watch the in-place mode exists to fix.
+//
+// Clearing those files does unlink an inode a pod may be watching, and leaves
+// the path missing until the atomic writer publishes its symlink, so a pod that
+// opens the file in between sees ENOENT. Both are inherent to rolling back to a
+// writer that replaces every file on every write.
+type atomicDirStorage struct {
+	inner innerStore
+}
+
+var _ storage.Interface = &atomicDirStorage{}
+
+func newAtomicDirStorage(inner innerStore) *atomicDirStorage {
+	return &atomicDirStorage{inner: inner}
+}
+
+func (s *atomicDirStorage) PathForVolume(volumeID string) string {
+	return s.inner.PathForVolume(volumeID)
+}
+
+func (s *atomicDirStorage) RemoveVolume(volumeID string) error {
+	return s.inner.RemoveVolume(volumeID)
+}
+
+func (s *atomicDirStorage) ReadMetadata(volumeID string) (metadata.Metadata, error) {
+	return s.inner.ReadMetadata(volumeID)
+}
+
+func (s *atomicDirStorage) ListVolumes() ([]string, error) {
+	return s.inner.ListVolumes()
+}
+
+func (s *atomicDirStorage) WriteMetadata(volumeID string, meta metadata.Metadata) error {
+	return s.inner.WriteMetadata(volumeID, meta)
+}
+
+func (s *atomicDirStorage) RegisterMetadata(meta metadata.Metadata) (bool, error) {
+	return s.inner.RegisterMetadata(meta)
+}
+
+func (s *atomicDirStorage) ReadFile(volumeID, name string) ([]byte, error) {
+	return s.inner.ReadFile(volumeID, name)
+}
+
+func (s *atomicDirStorage) WriteFiles(meta metadata.Metadata, files map[string][]byte) error {
+	// Validate before clearing anything: the inner writer applies the same rules
+	// and would reject the payload afterwards, leaving the volume emptied for a
+	// write that was never going to happen.
+	if err := validatePayloadNames(files); err != nil {
+		return err
+	}
+
+	if err := clearInplaceArtifacts(s.inner.PathForVolume(meta.VolumeID)); err != nil {
+		return err
+	}
+
+	return s.inner.WriteFiles(meta, files)
+}
+
+// clearInplaceArtifacts removes what the in-place writer left in the root of the
+// volume's data directory, so that a subsequent write by the csi-lib atomic
+// writer is actually visible to the mounted pod.
+//
+// util.AtomicWriter.createUserVisibleFiles decides whether it has to create the
+// user-visible symlink for a payload name by calling os.Readlink on it and
+// testing the error with os.IsNotExist. On anything that is not a symlink
+// Readlink fails with EINVAL, not ENOENT, so the branch is skipped: no symlink is
+// created, Write still returns nil, and everything the atomic writer wrote sits
+// in a timestamped directory that nothing points at. The pod goes on reading the
+// stale path indefinitely and no error is reported anywhere.
+//
+// Both regular files and real directories have to go, and only symlinks may
+// stay. Every root-level entry the atomic writer owns is either a symlink (the
+// `..data` link, and one per first path segment of a payload name - see
+// createUserVisibleFiles, which symlinks the segment rather than creating a
+// directory) or `..`-prefixed bookkeeping (`..data` and the timestamped
+// directories). So a non-`..` regular file or real directory in the root can only
+// be an in-place artifact: the file from a flat payload name, or the parent
+// directory writeFileInPlace creates for a nested one. Removing it is precisely
+// what lets createUserVisibleFiles create the symlink.
+func clearInplaceArtifacts(dataPath string) error {
+	entries, err := os.ReadDir(dataPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// Nothing has been written yet; the atomic writer builds the layout
+		// from scratch.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("listing data directory %q: %w", dataPath, err)
+	}
+
+	for _, entry := range entries {
+		// Symlinks are the atomic writer's own user-visible entries: leave them
+		// be, they are what it expects to find and reuse.
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		// `..`-prefixed entries are its bookkeeping, and a payload name can never
+		// collide with them (see validatePayloadName).
+		if strings.HasPrefix(entry.Name(), atomicReservedPrefix) {
+			continue
+		}
+
+		target := filepath.Join(dataPath, entry.Name())
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("removing in-place written path %q: %w", target, err)
+		}
+	}
+
+	return nil
+}
+
+// removeUnlistedFiles deletes the root-level entries of the data directory that
+// the payload does not contain, so that a write means the same thing it does
+// upstream: the payload is the complete desired file set, not a partial update.
+// Without this a file that stops being generated - a keystore after keystore
+// support is switched off, or a file that was renamed - would be served to the
+// pod forever.
+//
+// Only root-level entries are pruned, as in upstream removeUserVisiblePaths, and
+// `..`-prefixed names are preserved. Upstream then loses the superseded contents
+// by rebuilding the timestamped directory from scratch, which the in-place writer
+// deliberately never does - so in a legacy `..data` layout this removes the
+// user-visible symlink *and* the file it pointed at inside the timestamped
+// directory, leaving `..data`, the directory itself and every other file in it
+// untouched. Deleting the file behind the link matters for more than tidiness:
+// upstream's pathsToRemove walks the timestamped directory, and a file left there
+// with no user-visible link makes the first atomic-dir write after a rollback fail
+// in removeUserVisiblePaths, trying to os.Remove a path that is already gone.
+//
+// One consequence of pruning only the root is that an obsolete file inside a
+// payload subdirectory survives. No payload this driver produces is nested, so
+// nothing relies on that today.
+//
+// Callers must run this before the writes, so the certificate - written last -
+// still fires the event that tells the consumer the on-disk set is final.
+func removeUnlistedFiles(dataPath string, files map[string][]byte) error {
+	entries, err := os.ReadDir(dataPath)
+	if err != nil {
+		return fmt.Errorf("listing data directory %q: %w", dataPath, err)
+	}
+
+	wanted := make(map[string]struct{}, len(files))
+	for name := range files {
+		wanted[payloadRootName(name)] = struct{}{}
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasPrefix(name, atomicReservedPrefix) {
+			continue
+		}
+		if _, ok := wanted[name]; ok {
+			continue
+		}
+
+		// A symlink here is a user-visible link into `..data`; drop what it points
+		// at as well, so nothing is left in the timestamped directory without a
+		// link to it. RemoveAll rather than Remove: it treats an already absent
+		// path as success, and handles the directory a nested payload name would
+		// have put there. The trailing element is never followed, but the
+		// intermediate `..data` link is, so this reaches outside the volume if
+		// `..data` itself has been maliciously re-pointed - the same trust
+		// boundary as the O_NOFOLLOW note on writeFileInPlace: only a node-level
+		// writer could plant such a link, since pods mount the volume read-only.
+		if entry.Type()&os.ModeSymlink != 0 {
+			behindLink := filepath.Join(dataPath, atomicDataDirName, name)
+			if err := os.RemoveAll(behindLink); err != nil {
+				return fmt.Errorf("removing obsolete path %q: %w", behindLink, err)
+			}
+		}
+
+		target := filepath.Join(dataPath, name)
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("removing obsolete path %q: %w", target, err)
+		}
+	}
+
+	return nil
+}
+
+// payloadRootName returns the first path element of a cleaned payload name,
+// which is the root-level entry that name occupies in the data directory. It is
+// the same value upstream createUserVisibleFiles symlinks, and the cleaning
+// mirrors upstream validatePayload keying its payload by filepath.Clean.
+func payloadRootName(name string) string {
+	clean := filepath.Clean(name)
+	if i := strings.Index(clean, string(os.PathSeparator)); i != -1 {
+		return clean[:i]
+	}
+
+	return clean
+}
+
+// validatePayloadNames rejects a payload before anything is written, applying
+// the same rules as validatePath in csi-lib's vendored copy of the Kubernetes
+// atomic writer. The in-place writer bypasses that writer, so it has to do the
+// validation itself: without it a name such as `../../metadata.json` would
+// escape the volume's data directory.
+func validatePayloadNames(files map[string][]byte) error {
+	for name := range files {
+		if err := validatePayloadName(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePayloadName mirrors validatePath in csi-lib's vendored atomic writer,
+// plus one stricter rule (no `.`, see below).
+// A name may not be empty or absolute, may not contain `..` as a path element,
+// may not have a first element that starts with `..` and is longer than two
+// characters (the writer reserves those for its own bookkeeping), may not exceed
+// inplaceMaxPathLength in total and may not contain an element longer than
+// inplaceMaxFileNameLength.
+func validatePayloadName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid path: must not be empty: %q", name)
+	}
+	if path.IsAbs(name) {
+		return fmt.Errorf("invalid path: must be relative path: %s", name)
+	}
+	// Stricter than upstream, which accepts `.`: here it would make
+	// removeUnlistedFiles prune the whole data directory and the write then fail
+	// on the directory itself, leaving the volume empty.
+	if filepath.Clean(name) == "." {
+		return fmt.Errorf("invalid path: must name a file, not the data directory itself: %q", name)
+	}
+	if len(name) > inplaceMaxPathLength {
+		return fmt.Errorf("invalid path: must be less than or equal to %d characters", inplaceMaxPathLength)
+	}
+
+	items := strings.Split(name, string(os.PathSeparator))
+	for _, item := range items {
+		if item == ".." {
+			return fmt.Errorf("invalid path: must not contain '..': %s", name)
+		}
+		if len(item) > inplaceMaxFileNameLength {
+			return fmt.Errorf("invalid path: filenames must be less than or equal to %d characters",
+				inplaceMaxFileNameLength)
+		}
+	}
+	if strings.HasPrefix(items[0], atomicReservedPrefix) && len(items[0]) > 2 {
+		return fmt.Errorf("invalid path: must not start with '..': %s", name)
 	}
 
 	return nil
@@ -195,9 +550,51 @@ func orderedWriteNames(files map[string][]byte, certFileName string) []string {
 	return names
 }
 
-// anyDanglingSymlink reports whether any of the files about to be written
-// currently exists as a symlink whose chain no longer resolves to a real file.
-func anyDanglingSymlink(dataPath string, files map[string][]byte) (bool, error) {
+// brokenAtomicLayout reports whether the volume still holds an atomic-writer
+// layout that has been torn half down, which no amount of writing through it can
+// repair. Only then may a caller hand the volume back to the atomic writer,
+// because doing so deletes the timestamped directory and with it every inode a
+// pod is watching.
+//
+// Two shapes qualify:
+//
+//   - `..data` is a symlink that no longer resolves. Every user-visible symlink
+//     points through it, so no file in the volume can be opened.
+//   - `..data` is absent entirely and a payload name is a symlink that does not
+//     resolve. It can only point into the data directory that is gone, and
+//     opening it with O_CREATE would fail with ENOENT.
+//
+// A dangling per-file symlink while `..data` does resolve is explicitly healthy:
+// O_CREATE follows the chain and creates the file inside the timestamped
+// directory, repairing it in place. Treating that as broken - which an earlier
+// version of this check did - rebuilt the whole layout and destroyed the live
+// watches on every still-healthy sibling file, which is the failure this write
+// mode exists to prevent.
+func brokenAtomicLayout(dataPath string, files map[string][]byte) (bool, error) {
+	dataDir := filepath.Join(dataPath, atomicDataDirName)
+
+	info, err := os.Lstat(dataDir)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink == 0 {
+			// Not the writer's symlink; there is no chain to be broken.
+			return false, nil
+		}
+
+		if _, err := os.Stat(dataDir); errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		} else if err != nil {
+			return false, fmt.Errorf("resolving %q: %w", dataDir, err)
+		}
+
+		return false, nil
+
+	case !errors.Is(err, os.ErrNotExist):
+		return false, fmt.Errorf("checking %q: %w", dataDir, err)
+	}
+
+	// No `..data` at all, so a user-visible symlink cannot be repaired by
+	// writing through it.
 	for name := range files {
 		target := filepath.Join(dataPath, name)
 
@@ -226,11 +623,23 @@ func anyDanglingSymlink(dataPath string, files map[string][]byte) (bool, error) 
 // writeFileInPlace overwrites the contents of target, following any symlink
 // chain, without ever unlinking the file the pod is reading.
 func writeFileInPlace(target string, data []byte, fsGroup *int64) error {
-	// Lstat before opening so we can tell a file we are creating from one that
-	// already exists. Only a freshly created file needs its mode and group
-	// ownership set: re-applying them on every write is pure metadata churn
-	// that wakes every watcher with an IN_ATTRIB event for no reason.
-	_, err := os.Lstat(target)
+	// A nested payload name needs its parent directory created first, as
+	// upstream writePayloadToDir does and with the same os.ModePerm, so the
+	// mounting pod's user and group can traverse into it. For a flat name the
+	// parent is the data directory, which the caller has already created and
+	// which MkdirAll then leaves untouched.
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, os.ModePerm); err != nil {
+		return fmt.Errorf("creating parent directory %q: %w", parent, err)
+	}
+
+	// Stat, not Lstat, so we can tell a file we are creating from one that
+	// already exists: a dangling symlink counts as a create, because the file
+	// behind it is about to come into existence. Only a freshly created file
+	// needs its mode and group ownership set; re-applying them on every write is
+	// pure metadata churn that wakes every watcher with an IN_ATTRIB event for
+	// no reason.
+	_, err := os.Stat(target)
 	created := errors.Is(err, os.ErrNotExist)
 	if err != nil && !created {
 		return fmt.Errorf("checking existing file: %w", err)
@@ -243,12 +652,26 @@ func writeFileInPlace(target string, data []byte, fsGroup *int64) error {
 	// surface the real problem.
 	if !created {
 		if existing, err := os.ReadFile(target); err == nil && bytes.Equal(existing, data) {
-			return nil
+			// Content is already correct, but ownership may not be: the volume
+			// can be re-published with a different fsGroup without the
+			// certificate changing.
+			return ensureFileGroup(target, fsGroup)
 		}
 	}
 
 	// No O_TRUNC: truncating first would briefly expose a zero-length file to
-	// readers. No O_NOFOLLOW: following an existing symlink chain is deliberate.
+	// readers. No O_NOFOLLOW: following an existing symlink chain is deliberate,
+	// and it is what keeps a legacy `..data` layout working.
+	//
+	// That does mean a symlink already sitting in the data directory redirects
+	// this write to wherever it points, including outside the volume. Upstream is
+	// structurally immune because it only ever writes into a directory it just
+	// created. Here the argument is narrower: a pod cannot plant one, because
+	// csi-lib refuses a volume that is not readOnly and bind mounts the data
+	// directory `ro` into the pod (driver/nodeserver.go), so only something with
+	// write access to the node's own tmpfs could - and that already has the
+	// driver's privileges. Any change that loosens the read-only mount invalidates
+	// this reasoning and would need O_NOFOLLOW plus explicit chain validation.
 	f, openErr := os.OpenFile(target, os.O_WRONLY|os.O_CREATE, inplaceDataFileMode)
 	if openErr != nil {
 		return fmt.Errorf("opening file for writing: %w", openErr)
@@ -264,6 +687,13 @@ func writeFileInPlace(target string, data []byte, fsGroup *int64) error {
 		return fmt.Errorf("closing file: %w", err)
 	}
 
+	if !created {
+		// writeContentsInPlace deliberately leaves an existing file's metadata
+		// alone, so repair its group here if the volume's fsGroup has changed
+		// since the file was created.
+		return ensureFileGroup(target, fsGroup)
+	}
+
 	return nil
 }
 
@@ -274,8 +704,17 @@ func writeContentsInPlace(f *os.File, data []byte, created bool, fsGroup *int64)
 		return fmt.Errorf("writing contents: %w", err)
 	}
 
-	// Drop anything left over from a longer previous version of the file. This
-	// happens after the write so readers never observe a short file.
+	// Drop anything left over from a longer previous version of the file.
+	//
+	// This is not atomic against a concurrent reader, and neither is the WriteAt
+	// above: between the two syscalls a reader can observe the new content
+	// followed by the tail of the old (the window is widest when the new content
+	// is shorter), and a multi-page write is not atomic on tmpfs either. What
+	// does hold is the event ordering: both syscalls emit IN_MODIFY, so the last
+	// event a watcher receives is always emitted after the final content is
+	// complete. A consumer that re-reads on every event therefore converges; one
+	// that reads inside the window has to tolerate a parse failure until the
+	// next event arrives.
 	if err := f.Truncate(int64(len(data))); err != nil {
 		return fmt.Errorf("truncating to written length: %w", err)
 	}
@@ -297,6 +736,31 @@ func writeContentsInPlace(f *os.File, data []byte, created bool, fsGroup *int64)
 		if err := f.Chown(-1, int(*fsGroup)); err != nil {
 			return fmt.Errorf("setting file gid to %d: %w", *fsGroup, err)
 		}
+	}
+
+	return nil
+}
+
+// ensureFileGroup chowns target to fsGroup, but only if it is not already owned
+// by that group: an unconditional chown emits IN_ATTRIB and wakes every watcher
+// for a change that did not happen.
+func ensureFileGroup(target string, fsGroup *int64) error {
+	if fsGroup == nil {
+		return nil
+	}
+
+	// Stat, not Lstat: ownership belongs on the file the symlink chain resolves
+	// to, which is the file the pod actually reads.
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("stat %q: %w", target, err)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && int64(stat.Gid) == *fsGroup {
+		return nil
+	}
+
+	if err := os.Chown(target, -1, int(*fsGroup)); err != nil {
+		return fmt.Errorf("failed to chown %q to gid %v: %w", target, *fsGroup, err)
 	}
 
 	return nil
@@ -331,13 +795,16 @@ func ensureDataDirGroup(dataPath string, fsGroup *int64) error {
 // resolution csi-lib's Filesystem performs, which is unexported there.
 func (s *inplaceWriteStorage) fsGroupForMetadata(meta metadata.Metadata) (*int64, error) {
 	// The volume attribute takes precedence over the VolumeMountGroup set via
-	// securityContext.fsGroup, so ownership can be controlled per volume.
-	fsGroupStr := ""
+	// securityContext.fsGroup, so ownership can be controlled per volume. The
+	// source is tracked so an error names the field the operator actually set.
+	fsGroupStr, source := "", ""
 	if len(s.fsGroupVolumeAttributeKey) > 0 {
 		fsGroupStr = meta.VolumeContext[s.fsGroupVolumeAttributeKey]
+		source = fmt.Sprintf("volume attribute %q", s.fsGroupVolumeAttributeKey)
 	}
 	if fsGroupStr == "" {
 		fsGroupStr = meta.VolumeMountGroup
+		source = "volume mount group"
 	}
 	if fsGroupStr == "" {
 		return nil, nil
@@ -345,15 +812,15 @@ func (s *inplaceWriteStorage) fsGroupForMetadata(meta metadata.Metadata) (*int64
 
 	fsGroup, err := strconv.ParseInt(fsGroupStr, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse %q, value must be a valid integer: %w",
-			s.fsGroupVolumeAttributeKey, err)
+		return nil, fmt.Errorf("failed to parse %s value %q, value must be a valid integer: %w",
+			source, fsGroupStr, err)
 	}
 
 	// 4294967295 is the largest gid on most modern operating systems. A smaller
 	// real maximum will simply fail later during the chown.
 	if fsGroup <= 0 || fsGroup > 4294967295 {
-		return nil, fmt.Errorf("%q: gid value must be greater than 0 and less than 4294967295: %d",
-			s.fsGroupVolumeAttributeKey, fsGroup)
+		return nil, fmt.Errorf("%s: gid value must be greater than 0 and less than 4294967295: %d",
+			source, fsGroup)
 	}
 
 	return &fsGroup, nil

--- a/internal/csi/driver/storage_inplace_test.go
+++ b/internal/csi/driver/storage_inplace_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package driver
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,9 +26,29 @@ import (
 	"time"
 
 	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/cert-manager/csi-lib/storage"
+	"github.com/cert-manager/csi-lib/third_party/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// writeWithRealAtomicWriter runs the actual csi-lib atomic writer over dataPath.
+// The fake inner store cannot cover the rollback path: the whole failure mode is
+// that the real writer reports success while silently dropping the write, so the
+// only way to prove a rollback works is to run it.
+func writeWithRealAtomicWriter(t *testing.T, dataPath string, files map[string]string) error {
+	t.Helper()
+
+	writer, err := util.NewAtomicWriter(dataPath, "test")
+	require.NoError(t, err)
+
+	payload := map[string]util.FileProjection{}
+	for name, data := range files {
+		payload[name] = util.FileProjection{Data: []byte(data), Mode: int32(inplaceDataFileMode)}
+	}
+
+	return writer.Write(payload, nil)
+}
 
 // fakeInnerStore stands in for *storage.Filesystem. The real one cannot be used
 // in a unit test: storage.NewFilesystem mounts a tmpfs, and the fields needed to
@@ -39,6 +60,14 @@ type fakeInnerStore struct {
 	// in-place writer is expected to delegate only when the existing symlink
 	// layout is broken beyond in-place repair.
 	writeFilesCalls int
+
+	// sawNonSymlinkEntries records the root-level entries that were still in the
+	// data directory when the delegation happened and were not symlinks. The real
+	// atomic writer probes each payload name with os.Readlink and only publishes
+	// the user-visible symlink when that fails with ENOENT; a regular file or a
+	// real directory fails with EINVAL instead, so the write is silently dropped
+	// and anything recorded here would never have reached the pod.
+	sawNonSymlinkEntries []string
 }
 
 func (f *fakeInnerStore) PathForVolume(volumeID string) string { return f.dataPath }
@@ -52,11 +81,28 @@ func (f *fakeInnerStore) WriteMetadata(string, metadata.Metadata) error    { ret
 func (f *fakeInnerStore) RegisterMetadata(metadata.Metadata) (bool, error) { return false, nil }
 func (f *fakeInnerStore) ReadFile(string, string) ([]byte, error)          { return nil, nil }
 
-// WriteFiles records the delegation. On a healthy volume the in-place writer
-// does all writing itself; it only hands over to the inner atomic writer to
-// rebuild a volume whose symlink layout is broken.
+// WriteFiles records the delegation and the state of the data directory at that
+// moment. On a healthy volume the in-place writer does all writing itself; it
+// only hands over to the inner atomic writer to rebuild a volume whose symlink
+// layout is broken, or when the driver is running in atomic-dir mode.
 func (f *fakeInnerStore) WriteFiles(metadata.Metadata, map[string][]byte) error {
 	f.writeFilesCalls++
+
+	f.sawNonSymlinkEntries = []string{}
+	entries, err := os.ReadDir(f.dataPath)
+	if err != nil {
+		return fmt.Errorf("fake inner store: listing %q: %w", f.dataPath, err)
+	}
+	for _, entry := range entries {
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		if strings.HasPrefix(entry.Name(), atomicReservedPrefix) {
+			continue
+		}
+		f.sawNonSymlinkEntries = append(f.sawNonSymlinkEntries, entry.Name())
+	}
+
 	return nil
 }
 
@@ -235,18 +281,23 @@ func Test_inplaceWriteStorage_WriteFiles_skipsIdenticalContent(t *testing.T) {
 	require.NoError(t, s.WriteFiles(meta, map[string][]byte{"tls.crt": []byte("same")}))
 
 	target := filepath.Join(dataPath, "tls.crt")
-	before, err := os.Stat(target)
-	require.NoError(t, err)
+
+	// Backdate the file to a sentinel rather than sleeping between the writes:
+	// the modification time only has to differ from "now", and a sleep short
+	// enough to keep the test fast is below the timestamp resolution of several
+	// common file systems, which made this assertion pass regardless.
+	sentinel := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(target, sentinel, sentinel))
 
 	// Deliberately no makeWritableForRewrite: an identical write must return
 	// before even opening the file, so the 0440 mode never gets in the way.
-	time.Sleep(20 * time.Millisecond)
 	require.NoError(t, s.WriteFiles(meta, map[string][]byte{"tls.crt": []byte("same")}))
 
 	after, err := os.Stat(target)
 	require.NoError(t, err)
-	assert.Equal(t, before.ModTime(), after.ModTime(),
-		"identical content was rewritten; the pod's watcher would be woken for a no-op reload")
+	assert.True(t, after.ModTime().Equal(sentinel),
+		"identical content was rewritten (mod time moved from %s to %s); the pod's watcher "+
+			"would be woken for a no-op reload", sentinel, after.ModTime())
 }
 
 // A half-torn-down atomic-writer layout (a `..data` chain whose timestamped
@@ -273,6 +324,553 @@ func Test_inplaceWriteStorage_WriteFiles_rebuildsBrokenSymlinkLayout(t *testing.
 	// Nothing must have been written in place around the broken chain.
 	_, err := os.Stat(filepath.Join(dataPath, "tls.key"))
 	assert.True(t, os.IsNotExist(err), "the in-place path must not run once the layout is known to be broken")
+}
+
+// writeLegacyAtomicLayout builds the `..data` symlink layout the csi-lib atomic
+// writer leaves behind, with the given name/content pairs living inside the
+// timestamped directory. It returns the timestamped directory.
+func writeLegacyAtomicLayout(t *testing.T, dataPath string, files map[string]string) string {
+	t.Helper()
+
+	const tsName = "..2026_01_01_00_00_00.1"
+	tsDir := filepath.Join(dataPath, tsName)
+	require.NoError(t, os.MkdirAll(tsDir, 0o755))
+
+	for name, data := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(tsDir, name), []byte(data), 0o640))
+		require.NoError(t, os.Symlink(
+			filepath.Join(atomicDataDirName, name), filepath.Join(dataPath, name)))
+	}
+	require.NoError(t, os.Symlink(tsName, filepath.Join(dataPath, atomicDataDirName)))
+
+	return tsDir
+}
+
+// Rolling back to `--volume-write-mode=atomic-dir` on a node the in-place writer
+// has already run on must actually deliver renewals. The atomic writer probes
+// each payload name with os.Readlink and only creates the user-visible symlink
+// when that fails with ENOENT; on a regular file it fails with EINVAL, so the
+// symlink is never created, Write() still returns nil, and the pod keeps reading
+// the stale regular file forever. The wrapper has to clear those files first.
+func Test_atomicDirStorage_WriteFiles_clearsInplaceRegularFiles(t *testing.T) {
+	inplace, dataPath := newTestInplaceStorage(t, "tls.crt")
+	fake := inplace.inner.(*fakeInnerStore)
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, inplace.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("cert"),
+		"tls.key": []byte("key"),
+	}))
+	for _, name := range []string{"tls.crt", "tls.key"} {
+		info, err := os.Lstat(filepath.Join(dataPath, name))
+		require.NoError(t, err)
+		require.True(t, info.Mode().IsRegular(), "%q should have been written as a regular file", name)
+	}
+
+	atomicDir := newAtomicDirStorage(fake)
+	require.NoError(t, atomicDir.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("cert-2"),
+		"tls.key": []byte("key-2"),
+	}))
+
+	assert.Equal(t, 1, fake.writeFilesCalls,
+		"the atomic-dir wrapper must still delegate the write to the csi-lib atomic writer")
+	assert.Empty(t, fake.sawNonSymlinkEntries,
+		"the in-place regular files were still present when the atomic writer ran; it would "+
+			"have skipped creating their user-visible symlinks and silently written to a "+
+			"timestamped directory nothing points at")
+
+	// The fake writes nothing, so the files must simply be gone.
+	for _, name := range []string{"tls.crt", "tls.key"} {
+		_, err := os.Lstat(filepath.Join(dataPath, name))
+		assert.True(t, os.IsNotExist(err), "%q should have been cleared before delegation", name)
+	}
+}
+
+// A nested payload name makes the in-place writer create a real directory at the
+// data-dir root, and os.Readlink fails with EINVAL on a directory just as it does
+// on a regular file. Upstream never puts a real directory there - it symlinks the
+// first path segment into `..data` - so the wrapper must clear directories too or
+// the rollback silently stalls on the old nested contents.
+func Test_atomicDirStorage_WriteFiles_clearsInplaceDirectories(t *testing.T) {
+	inplace, dataPath := newTestInplaceStorage(t, "tls.crt")
+	fake := inplace.inner.(*fakeInnerStore)
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, inplace.WriteFiles(meta, map[string][]byte{"sub/ca.crt": []byte("ca")}))
+
+	info, err := os.Lstat(filepath.Join(dataPath, "sub"))
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "the in-place writer should have created `sub` as a real directory")
+
+	atomicDir := newAtomicDirStorage(fake)
+	require.NoError(t, atomicDir.WriteFiles(meta, map[string][]byte{"sub/ca.crt": []byte("ca-2")}))
+
+	assert.Equal(t, 1, fake.writeFilesCalls, "the write must still be delegated")
+	assert.Empty(t, fake.sawNonSymlinkEntries,
+		"the in-place directory was still present when the atomic writer ran; os.Readlink on it "+
+			"fails with EINVAL, so no user-visible symlink is created, Write() returns nil and "+
+			"the pod keeps reading the old sub/ca.crt forever")
+
+	_, err = os.Lstat(filepath.Join(dataPath, "sub"))
+	assert.True(t, os.IsNotExist(err), "`sub` should have been cleared before delegation")
+}
+
+// Clearing is destructive, so it must not happen for a payload the inner writer
+// is going to reject anyway - that would empty the volume for a write that never
+// had a chance of succeeding.
+func Test_atomicDirStorage_WriteFiles_validatesBeforeClearing(t *testing.T) {
+	inplace, dataPath := newTestInplaceStorage(t, "tls.crt")
+	fake := inplace.inner.(*fakeInnerStore)
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, inplace.WriteFiles(meta, map[string][]byte{"tls.crt": []byte("cert")}))
+
+	atomicDir := newAtomicDirStorage(fake)
+	err := atomicDir.WriteFiles(meta, map[string][]byte{"../oops": []byte("nope")})
+	require.Error(t, err, "an escaping payload name must be rejected")
+
+	assert.Equal(t, 0, fake.writeFilesCalls, "an invalid payload must not be delegated")
+	assert.FileExists(t, filepath.Join(dataPath, "tls.crt"),
+		"the existing certificate was cleared for a write that could never succeed")
+}
+
+// camanager picks its write path by type-asserting the store to
+// singleFileWriter. atomic-dir mode must not satisfy it: the atomic writer
+// treats its payload as the complete desired contents of the volume, so a
+// CA-only payload would delete the certificate and key.
+func Test_writeModeSurfaces_singleFileWriter(t *testing.T) {
+	var atomicDir storage.Interface = newAtomicDirStorage(&fakeInnerStore{})
+	_, ok := atomicDir.(singleFileWriter)
+	assert.False(t, ok,
+		"atomicDirStorage must not implement singleFileWriter: camanager would send the atomic "+
+			"writer a CA-only payload and it would prune the certificate and key")
+
+	var inplace storage.Interface = &inplaceWriteStorage{}
+	_, ok = inplace.(singleFileWriter)
+	assert.True(t, ok,
+		"inplaceWriteStorage must implement singleFileWriter, or camanager falls back to the "+
+			"read-keypair-then-rewrite path that races with certificate renewal")
+}
+
+// The broken-layout fallback inside WriteFiles hands the volume to the same
+// atomic writer, so it needs the same clean-up: a volume can hold both a torn
+// `..data` chain and regular files written in place before the chain broke.
+func Test_inplaceWriteStorage_WriteFiles_brokenLayoutFallbackClearsRegularFiles(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	// A `..data` chain whose timestamped directory is gone, next to a regular
+	// file the in-place writer left behind.
+	require.NoError(t, os.Symlink("..2026_01_01_00_00_00.1", filepath.Join(dataPath, atomicDataDirName)))
+	require.NoError(t, os.WriteFile(filepath.Join(dataPath, "tls.key"), []byte("key"), 0o640))
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert-new"),
+		"tls.key": []byte("key-new"),
+	}))
+
+	fake := s.inner.(*fakeInnerStore)
+	assert.Equal(t, 1, fake.writeFilesCalls, "a broken `..data` chain must be rebuilt by the atomic writer")
+	assert.Empty(t, fake.sawNonSymlinkEntries,
+		"the atomic writer cannot publish over a regular file, so the fallback must clear them first")
+
+	assert.FileExists(t, filepath.Join(dataPath, atomicDataDirName),
+		"only regular files may be cleared; the `..data` symlink belongs to the atomic layout")
+}
+
+// The reviewer's reproduction: one healthy symlink chain and one dangling
+// sibling. `..data` still resolves, so O_CREATE through the sibling's symlink
+// creates the missing file inside the timestamped directory. Delegating instead
+// would rebuild the layout, delete the timestamped directory, and destroy the
+// pod's live watch on the perfectly healthy certificate.
+func Test_inplaceWriteStorage_WriteFiles_repairsDanglingSiblingUnderHealthyDataLink(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	tsDir := writeLegacyAtomicLayout(t, dataPath, map[string]string{"tls.crt": "cert-old"})
+
+	// service.jks is published but its backing file was never written.
+	require.NoError(t, os.Symlink(
+		filepath.Join(atomicDataDirName, "service.jks"), filepath.Join(dataPath, "service.jks")))
+
+	before := inodeOf(t, filepath.Join(tsDir, "tls.crt"))
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt":     []byte("cert-new"),
+		"service.jks": []byte("jks"),
+	}))
+
+	fake := s.inner.(*fakeInnerStore)
+	assert.Equal(t, 0, fake.writeFilesCalls,
+		"a dangling sibling symlink under a `..data` link that still resolves is repairable in "+
+			"place; delegating rebuilds the layout and destroys the watch on every healthy file")
+
+	assert.DirExists(t, tsDir, "the timestamped directory must not be deleted")
+	assert.Equal(t, before, inodeOf(t, filepath.Join(tsDir, "tls.crt")),
+		"the certificate was replaced instead of rewritten, destroying the pod's watch")
+
+	for name, want := range map[string]string{"tls.crt": "cert-new", "service.jks": "jks"} {
+		got, err := os.ReadFile(filepath.Join(dataPath, name))
+		require.NoError(t, err)
+		assert.Equal(t, want, string(got), "reader should observe the new content of %q", name)
+	}
+	assert.FileExists(t, filepath.Join(tsDir, "service.jks"),
+		"the missing file should have been created through the existing symlink chain")
+}
+
+// The payload is the complete desired contents of the volume, as it is upstream.
+// A file that stops being generated - a keystore after keystore support is
+// switched off, or a file that was renamed - must not be served forever.
+func Test_inplaceWriteStorage_WriteFiles_removesFilesMissingFromPayload(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt":        []byte("cert-1"),
+		"tls.key":        []byte("key-1"),
+		"service.pkcs12": []byte("p12"),
+	}))
+
+	before := map[string]uint64{
+		"tls.crt": inodeOf(t, filepath.Join(dataPath, "tls.crt")),
+		"tls.key": inodeOf(t, filepath.Join(dataPath, "tls.key")),
+	}
+	makeWritableForRewrite(t, dataPath, "tls.crt", "tls.key")
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("cert-2"),
+		"tls.key": []byte("key-2"),
+	}))
+
+	_, err := os.Lstat(filepath.Join(dataPath, "service.pkcs12"))
+	assert.True(t, os.IsNotExist(err),
+		"a file dropped from the payload is still on disk; the pod would keep reading a stale "+
+			"keystore that no longer matches the certificate")
+
+	for name, want := range map[string]string{"tls.crt": "cert-2", "tls.key": "key-2"} {
+		got, err := os.ReadFile(filepath.Join(dataPath, name))
+		require.NoError(t, err)
+		assert.Equal(t, want, string(got))
+		assert.Equal(t, before[name], inodeOf(t, filepath.Join(dataPath, name)),
+			"pruning must not disturb the inode of %q", name)
+	}
+}
+
+// In a legacy layout the entry to prune is the user-visible symlink, and the file
+// it pointed at inside the timestamped directory has to go with it. `..data`, the
+// timestamped directory itself and every file still in the payload must be left
+// alone.
+func Test_inplaceWriteStorage_WriteFiles_removesObsoleteUserVisibleSymlink(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	tsDir := writeLegacyAtomicLayout(t, dataPath, map[string]string{
+		"tls.crt":        "cert-old",
+		"service.pkcs12": "p12",
+	})
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert-new"),
+	}))
+
+	_, err := os.Lstat(filepath.Join(dataPath, "service.pkcs12"))
+	assert.True(t, os.IsNotExist(err), "the user-visible symlink of a dropped file must be removed")
+
+	// Leaving the superseded file in the timestamped directory desyncs a later
+	// atomic-dir rollback: upstream pathsToRemove walks that directory, finds an
+	// entry with no user-visible link, and removeUserVisiblePaths then fails
+	// trying to os.Remove a path that is already gone.
+	_, err = os.Lstat(filepath.Join(tsDir, "service.pkcs12"))
+	assert.True(t, os.IsNotExist(err),
+		"the file behind the pruned symlink is still in the timestamped directory; the first "+
+			"atomic-dir write after a rollback would fail and leave the old directory behind")
+
+	assert.DirExists(t, tsDir, "the timestamped directory is the atomic writer's; leave it alone")
+	assert.FileExists(t, filepath.Join(dataPath, atomicDataDirName), "`..data` must survive pruning")
+	assert.FileExists(t, filepath.Join(tsDir, "tls.crt"),
+		"only the pruned name may be removed from the timestamped directory")
+
+	got, err := os.ReadFile(filepath.Join(dataPath, "tls.crt"))
+	require.NoError(t, err)
+	assert.Equal(t, "cert-new", string(got))
+}
+
+// End-to-end rollback against the real atomic writer: after in-place has run,
+// clearing its artifacts must leave a volume the atomic writer can publish into.
+// The flat case covers the leftover regular file, the nested case the leftover
+// real directory - os.Readlink fails with EINVAL on both, and the writer treats
+// that as "the symlink already exists" and returns success having published
+// nothing.
+func Test_clearInplaceArtifacts_realAtomicWriterPublishesAfterwards(t *testing.T) {
+	for _, name := range []string{"tls.crt", "sub/ca.crt"} {
+		t.Run(name, func(t *testing.T) {
+			s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+			require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"},
+				map[string][]byte{name: []byte("in-place-bytes")}))
+
+			require.NoError(t, clearInplaceArtifacts(dataPath))
+			require.NoError(t, writeWithRealAtomicWriter(t, dataPath, map[string]string{name: "rolled-back"}))
+
+			got, err := os.ReadFile(filepath.Join(dataPath, name))
+			require.NoError(t, err)
+			assert.Equal(t, "rolled-back", string(got),
+				"the atomic writer reported success but %q still serves the in-place bytes: its "+
+					"os.Readlink probe failed with EINVAL on the leftover, so the user-visible "+
+					"symlink was never created and the write went to a directory nothing points at",
+				name)
+		})
+	}
+}
+
+// Pruning a user-visible symlink must also drop the file behind `..data`, or the
+// timestamped directory keeps an entry with no link to it. Upstream pathsToRemove
+// walks that directory and removeUserVisiblePaths then fails removing a path that
+// is already gone, so the first atomic write after a rollback errors out and
+// leaves the superseded directory behind.
+func Test_removeUnlistedFiles_realAtomicWriterRollbackSucceedsFirstTry(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	tsDir := writeLegacyAtomicLayout(t, dataPath, map[string]string{
+		"tls.crt":        "cert-old",
+		"service.pkcs12": "p12",
+	})
+
+	// Drop the keystore, as switching keystore support off does.
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert-new"),
+	}))
+
+	// Now roll back to the atomic writer.
+	require.NoError(t, clearInplaceArtifacts(dataPath))
+	require.NoError(t, writeWithRealAtomicWriter(t, dataPath, map[string]string{"tls.crt": "cert-rollback"}),
+		"the first atomic write after a rollback must succeed, not the second")
+
+	assert.NoDirExists(t, tsDir,
+		"the write failed before it could retire the superseded timestamped directory")
+
+	got, err := os.ReadFile(filepath.Join(dataPath, "tls.crt"))
+	require.NoError(t, err)
+	assert.Equal(t, "cert-rollback", string(got))
+}
+
+// WriteFile is the CA-only path camanager uses. It must never touch anything
+// but the named file, so that a certificate renewal running concurrently cannot
+// be rolled back by a trust bundle update.
+func Test_inplaceWriteStorage_WriteFile(t *testing.T) {
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	t.Run("creates the file on a fresh volume", func(t *testing.T) {
+		s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+		require.NoError(t, s.WriteFile(meta, "ca.crt", []byte("ca-1")))
+
+		got, err := os.ReadFile(filepath.Join(dataPath, "ca.crt"))
+		require.NoError(t, err)
+		assert.Equal(t, "ca-1", string(got))
+	})
+
+	t.Run("skips identical content", func(t *testing.T) {
+		s, dataPath := newTestInplaceStorage(t, "tls.crt")
+		require.NoError(t, s.WriteFile(meta, "ca.crt", []byte("ca-1")))
+
+		target := filepath.Join(dataPath, "ca.crt")
+		sentinel := time.Now().Add(-time.Hour).Truncate(time.Second)
+		require.NoError(t, os.Chtimes(target, sentinel, sentinel))
+
+		require.NoError(t, s.WriteFile(meta, "ca.crt", []byte("ca-1")))
+
+		after, err := os.Stat(target)
+		require.NoError(t, err)
+		assert.True(t, after.ModTime().Equal(sentinel),
+			"an unchanged trust bundle was rewritten, waking every watcher for a no-op reload")
+	})
+
+	t.Run("leaves unrelated files alone", func(t *testing.T) {
+		s, dataPath := newTestInplaceStorage(t, "tls.crt")
+		require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+			"tls.crt":     []byte("cert-1"),
+			"tls.key":     []byte("key-1"),
+			"service.jks": []byte("jks"),
+		}))
+
+		before := map[string]uint64{}
+		for _, name := range []string{"tls.crt", "tls.key", "service.jks"} {
+			before[name] = inodeOf(t, filepath.Join(dataPath, name))
+		}
+
+		require.NoError(t, s.WriteFile(meta, "ca.crt", []byte("ca-1")))
+
+		for name, want := range map[string]string{
+			"tls.crt": "cert-1", "tls.key": "key-1", "service.jks": "jks",
+		} {
+			got, err := os.ReadFile(filepath.Join(dataPath, name))
+			require.NoError(t, err)
+			assert.Equal(t, want, string(got),
+				"a CA-only write must not rewrite %q: the desired-state pruning and the "+
+					"read-then-write of the keypair are exactly what races with a renewal", name)
+			assert.Equal(t, before[name], inodeOf(t, filepath.Join(dataPath, name)),
+				"inode of %q changed during a CA-only write", name)
+		}
+	})
+
+	t.Run("writes through a legacy layout", func(t *testing.T) {
+		s, dataPath := newTestInplaceStorage(t, "tls.crt")
+		tsDir := writeLegacyAtomicLayout(t, dataPath, map[string]string{"ca.crt": "ca-old"})
+
+		before := inodeOf(t, filepath.Join(tsDir, "ca.crt"))
+
+		require.NoError(t, s.WriteFile(meta, "ca.crt", []byte("ca-new")))
+
+		assert.Equal(t, before, inodeOf(t, filepath.Join(tsDir, "ca.crt")),
+			"the trust bundle file was replaced instead of rewritten")
+		got, err := os.ReadFile(filepath.Join(dataPath, "ca.crt"))
+		require.NoError(t, err)
+		assert.Equal(t, "ca-new", string(got))
+	})
+
+	t.Run("errors on a broken layout instead of delegating", func(t *testing.T) {
+		s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+		require.NoError(t, os.Symlink("..2026_01_01_00_00_00.1",
+			filepath.Join(dataPath, atomicDataDirName)))
+		require.NoError(t, os.Symlink(filepath.Join(atomicDataDirName, "ca.crt"),
+			filepath.Join(dataPath, "ca.crt")))
+
+		err := s.WriteFile(meta, "ca.crt", []byte("ca-1"))
+		require.Error(t, err, "a broken `..data` chain cannot be written through")
+
+		assert.Equal(t, 0, s.inner.(*fakeInnerStore).writeFilesCalls,
+			"a single-file write must never reach the atomic writer: its payload is the "+
+				"complete desired state, so a CA-only payload would delete the keypair")
+	})
+}
+
+// The in-place writer bypasses the atomic writer, so it has to apply the same
+// path validation itself; without it a payload name could escape the volume.
+func Test_inplaceWriteStorage_WriteFiles_rejectsInvalidPayloadNames(t *testing.T) {
+	for _, name := range []string{"../escape", "/abs", "a/../b", "", ".", "./", "..data", strings.Repeat("x", 256)} {
+		t.Run(fmt.Sprintf("%q", name), func(t *testing.T) {
+			s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+			err := s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+				"tls.crt": []byte("cert"),
+				name:      []byte("payload"),
+			})
+			require.Error(t, err, "payload name %q must be rejected", name)
+
+			_, statErr := os.Lstat(filepath.Join(dataPath, "tls.crt"))
+			assert.True(t, os.IsNotExist(statErr),
+				"validation must reject the whole payload before anything is written")
+			assert.Equal(t, 0, s.inner.(*fakeInnerStore).writeFilesCalls,
+				"an invalid payload must not be handed to the atomic writer either")
+		})
+	}
+}
+
+// A nested payload name needs its parent directory created first, as upstream
+// writePayloadToDir does.
+func Test_inplaceWriteStorage_WriteFiles_nestedPayloadName(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"sub/ca.crt": []byte("ca"),
+	}))
+
+	assert.DirExists(t, filepath.Join(dataPath, "sub"), "the parent directory must be created")
+	got, err := os.ReadFile(filepath.Join(dataPath, "sub", "ca.crt"))
+	require.NoError(t, err)
+	assert.Equal(t, "ca", string(got))
+}
+
+// The key is read once at construction, so the inner store must already have it
+// set. A wrapper built before the key is assigned would silently ignore the
+// fs-group volume attribute.
+func Test_newInplaceWriteStorage_copiesFSGroupVolumeAttributeKey(t *testing.T) {
+	s := newInplaceWriteStorage(&storage.Filesystem{FSGroupVolumeAttributeKey: "k"}, "tls.crt")
+
+	assert.Equal(t, "k", s.fsGroupVolumeAttributeKey,
+		"the inner store's FSGroupVolumeAttributeKey was not copied; fs-group ownership "+
+			"would never be applied")
+	assert.Equal(t, "tls.crt", s.certFileName)
+}
+
+func gidOf(t *testing.T, path string) int64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "expected a *syscall.Stat_t for %q", path)
+
+	return int64(stat.Gid)
+}
+
+func Test_ensureFileGroup_nilFSGroupIsANoOp(t *testing.T) {
+	// A path that does not exist proves the nil check happens before the stat:
+	// with no fs-group configured, ownership must not be touched or inspected.
+	assert.NoError(t, ensureFileGroup(filepath.Join(t.TempDir(), "does-not-exist"), nil))
+}
+
+// twoOwnableGIDs returns two distinct gids the test process is allowed to chown
+// a file it owns to. root may use any gid; anyone else is limited to the groups
+// they are a member of, and the test is skipped when there are not two of them.
+func twoOwnableGIDs(t *testing.T) (int64, int64) {
+	t.Helper()
+
+	if os.Geteuid() == 0 {
+		return 1234, 4321
+	}
+
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+	if len(groups) < 2 {
+		t.Skip("chowning a file needs either root or membership of two groups")
+	}
+
+	return int64(groups[0]), int64(groups[1])
+}
+
+func Test_ensureFileGroup_repairsChangedGroup(t *testing.T) {
+	gidA, gidB := twoOwnableGIDs(t)
+
+	target := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(target, []byte("ca"), 0o640))
+
+	require.NoError(t, ensureFileGroup(target, &gidA))
+	assert.Equal(t, gidA, gidOf(t, target))
+
+	// Idempotent: a second call with the same gid must not fail.
+	require.NoError(t, ensureFileGroup(target, &gidA))
+	assert.Equal(t, gidA, gidOf(t, target))
+
+	require.NoError(t, ensureFileGroup(target, &gidB))
+	assert.Equal(t, gidB, gidOf(t, target))
+}
+
+// An existing file's ownership has to follow the volume's fs-group even when its
+// contents do not change: a volume can be re-published with a different fsGroup
+// while the certificate stays valid.
+func Test_writeFileInPlace_repairsGroupOfExistingFile(t *testing.T) {
+	gidA, gidB := twoOwnableGIDs(t)
+
+	target := filepath.Join(t.TempDir(), "tls.crt")
+
+	require.NoError(t, writeFileInPlace(target, []byte("cert-1"), &gidA))
+	require.Equal(t, gidA, gidOf(t, target))
+
+	t.Log("identical content, new fs-group")
+	require.NoError(t, writeFileInPlace(target, []byte("cert-1"), &gidB))
+	assert.Equal(t, gidB, gidOf(t, target),
+		"the early return for identical content skipped the ownership repair")
+
+	t.Log("new content, new fs-group")
+	if os.Geteuid() != 0 {
+		// Relax the 0440 mode the create set, so a non-root owner can reopen the
+		// file for writing. The driver itself runs as root.
+		require.NoError(t, os.Chmod(target, 0o640))
+	}
+	require.NoError(t, writeFileInPlace(target, []byte("cert-2"), &gidA))
+	assert.Equal(t, gidA, gidOf(t, target),
+		"a rewrite of an existing file skipped the ownership repair")
 }
 
 func Test_orderedWriteNames(t *testing.T) {
@@ -321,7 +919,10 @@ func Test_inplaceWriteStorage_fsGroupForMetadata(t *testing.T) {
 		volumeContext    map[string]string
 		volumeMountGroup string
 		expFSGroup       *int64
-		expErr           bool
+		// expErrContains, when set, is a substring the error must contain. The
+		// value can come from either source, so an error has to name the one the
+		// operator actually set rather than always blaming the attribute key.
+		expErrContains string
 	}{
 		"valid volume attribute": {
 			volumeContext: map[string]string{attrKey: "1234"},
@@ -337,16 +938,24 @@ func Test_inplaceWriteStorage_fsGroupForMetadata(t *testing.T) {
 			expFSGroup:       ptrInt64(4321),
 		},
 		"not a number": {
-			volumeContext: map[string]string{attrKey: "not-a-gid"},
-			expErr:        true,
+			volumeContext:  map[string]string{attrKey: "not-a-gid"},
+			expErrContains: `volume attribute "` + attrKey + `"`,
+		},
+		"not a number in the volume mount group": {
+			volumeMountGroup: "not-a-gid",
+			expErrContains:   "volume mount group",
 		},
 		"zero is out of range": {
-			volumeContext: map[string]string{attrKey: "0"},
-			expErr:        true,
+			volumeContext:  map[string]string{attrKey: "0"},
+			expErrContains: `volume attribute "` + attrKey + `"`,
 		},
 		"above the maximum gid": {
-			volumeContext: map[string]string{attrKey: "4294967296"},
-			expErr:        true,
+			volumeContext:  map[string]string{attrKey: "4294967296"},
+			expErrContains: `volume attribute "` + attrKey + `"`,
+		},
+		"out of range in the volume mount group": {
+			volumeMountGroup: "4294967296",
+			expErrContains:   "volume mount group",
 		},
 	}
 
@@ -358,8 +967,11 @@ func Test_inplaceWriteStorage_fsGroupForMetadata(t *testing.T) {
 				VolumeContext:    test.volumeContext,
 				VolumeMountGroup: test.volumeMountGroup,
 			})
-			if test.expErr {
-				assert.Error(t, err)
+			if test.expErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.expErrContains,
+					"the error must name the field the gid was read from, not always the "+
+						"volume attribute key")
 				return
 			}
 

--- a/internal/csi/driver/storage_inplace_test.go
+++ b/internal/csi/driver/storage_inplace_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright The Athenz Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cert-manager/csi-lib/metadata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeInnerStore stands in for *storage.Filesystem. The real one cannot be used
+// in a unit test: storage.NewFilesystem mounts a tmpfs, and the fields needed to
+// build one by hand are unexported.
+type fakeInnerStore struct {
+	dataPath string
+
+	// writeFilesCalls counts delegations to the inner (atomic) writer. The
+	// in-place writer is expected to delegate only when the existing symlink
+	// layout is broken beyond in-place repair.
+	writeFilesCalls int
+}
+
+func (f *fakeInnerStore) PathForVolume(volumeID string) string { return f.dataPath }
+func (f *fakeInnerStore) RemoveVolume(string) error            { return nil }
+func (f *fakeInnerStore) ListVolumes() ([]string, error)       { return nil, nil }
+
+func (f *fakeInnerStore) ReadMetadata(string) (metadata.Metadata, error) {
+	return metadata.Metadata{}, nil
+}
+func (f *fakeInnerStore) WriteMetadata(string, metadata.Metadata) error    { return nil }
+func (f *fakeInnerStore) RegisterMetadata(metadata.Metadata) (bool, error) { return false, nil }
+func (f *fakeInnerStore) ReadFile(string, string) ([]byte, error)          { return nil, nil }
+
+// WriteFiles records the delegation. On a healthy volume the in-place writer
+// does all writing itself; it only hands over to the inner atomic writer to
+// rebuild a volume whose symlink layout is broken.
+func (f *fakeInnerStore) WriteFiles(metadata.Metadata, map[string][]byte) error {
+	f.writeFilesCalls++
+	return nil
+}
+
+var _ innerStore = &fakeInnerStore{}
+
+// newTestInplaceStorage returns an in-place writer over a temp data directory,
+// plus that directory. The directory is created up-front with a mode that
+// permits writes: the production mode (0550) relies on the driver running as
+// root.
+func newTestInplaceStorage(t *testing.T, certFileName string) (*inplaceWriteStorage, string) {
+	t.Helper()
+
+	dataPath := filepath.Join(t.TempDir(), "data")
+	require.NoError(t, os.MkdirAll(dataPath, 0o755))
+
+	return &inplaceWriteStorage{
+		inner:                     &fakeInnerStore{dataPath: dataPath},
+		certFileName:              certFileName,
+		fsGroupVolumeAttributeKey: "csi.cert-manager.athenz.io/fs-group",
+	}, dataPath
+}
+
+// makeWritableForRewrite relaxes the 0440 mode of already-written files so a
+// second WriteFiles can reopen them as a non-root test user. The driver itself
+// runs as root, where reopening a 0440 file for writing is allowed.
+func makeWritableForRewrite(t *testing.T, dataPath string, names ...string) {
+	t.Helper()
+
+	if os.Geteuid() == 0 {
+		return
+	}
+	for _, name := range names {
+		require.NoError(t, os.Chmod(filepath.Join(dataPath, name), 0o640))
+	}
+}
+
+func inodeOf(t *testing.T, path string) uint64 {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok, "expected a *syscall.Stat_t for %q", path)
+
+	return uint64(stat.Ino)
+}
+
+func Test_inplaceWriteStorage_WriteFiles_preservesInodes(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	names := []string{"tls.crt", "tls.key", "ca.crt"}
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("cert-1"),
+		"tls.key": []byte("key-1"),
+		"ca.crt":  []byte("ca-1"),
+	}))
+
+	before := map[string]uint64{}
+	for _, name := range names {
+		before[name] = inodeOf(t, filepath.Join(dataPath, name))
+	}
+
+	makeWritableForRewrite(t, dataPath, names...)
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("cert-2"),
+		"tls.key": []byte("key-2"),
+		"ca.crt":  []byte("ca-2"),
+	}))
+
+	for _, name := range names {
+		assert.Equal(t, before[name], inodeOf(t, filepath.Join(dataPath, name)),
+			"inode of %q changed across writes: the file was replaced rather than "+
+				"rewritten in place (a temp file + rename, or the csi-lib atomic "+
+				"writer, does exactly this). Any inotify watch a pod holds on this "+
+				"file is destroyed, and the consumer keeps serving a stale cert.", name)
+	}
+
+	for name, want := range map[string]string{
+		"tls.crt": "cert-2",
+		"tls.key": "key-2",
+		"ca.crt":  "ca-2",
+	} {
+		got, err := os.ReadFile(filepath.Join(dataPath, name))
+		require.NoError(t, err)
+		assert.Equal(t, want, string(got), "reader should observe the second write of %q", name)
+	}
+}
+
+func Test_inplaceWriteStorage_WriteFiles_freshVolumeLayout(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert"),
+		"tls.key": []byte("key"),
+	}))
+
+	entries, err := os.ReadDir(dataPath)
+	require.NoError(t, err)
+
+	var got []string
+	for _, entry := range entries {
+		assert.False(t, strings.HasPrefix(entry.Name(), ".."),
+			"unexpected atomic-writer entry %q in the data directory", entry.Name())
+		got = append(got, entry.Name())
+	}
+	assert.ElementsMatch(t, []string{"tls.crt", "tls.key"}, got)
+
+	for _, name := range []string{"tls.crt", "tls.key"} {
+		info, err := os.Lstat(filepath.Join(dataPath, name))
+		require.NoError(t, err)
+		assert.True(t, info.Mode().IsRegular(), "%q should be a regular file, not a symlink", name)
+		assert.Equal(t, os.FileMode(0o440), info.Mode().Perm(), "mode of %q", name)
+	}
+}
+
+// A volume previously written by the csi-lib atomic writer still has the
+// `..data` symlink layout. Writing must follow that chain: recreating the layout
+// would unlink the inode the running pod is watching.
+func Test_inplaceWriteStorage_WriteFiles_writesThroughLegacyDataSymlink(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	tsDir := filepath.Join(dataPath, "..2026_01_01_00_00_00.1")
+	require.NoError(t, os.MkdirAll(tsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(tsDir, "tls.crt"), []byte("cert-old"), 0o640))
+	require.NoError(t, os.Symlink("..2026_01_01_00_00_00.1", filepath.Join(dataPath, "..data")))
+	require.NoError(t, os.Symlink(filepath.Join("..data", "tls.crt"), filepath.Join(dataPath, "tls.crt")))
+
+	before := inodeOf(t, filepath.Join(tsDir, "tls.crt"))
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert-new"),
+	}))
+
+	info, err := os.Lstat(filepath.Join(dataPath, "tls.crt"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink,
+		"the existing `..data` symlink layout must be left in place")
+
+	assert.DirExists(t, tsDir, "the timestamped directory must not be deleted")
+	assert.Equal(t, before, inodeOf(t, filepath.Join(tsDir, "tls.crt")),
+		"the underlying file was replaced instead of rewritten, destroying the pod's watch")
+
+	got, err := os.ReadFile(filepath.Join(dataPath, "tls.crt"))
+	require.NoError(t, err)
+	assert.Equal(t, "cert-new", string(got))
+}
+
+func Test_inplaceWriteStorage_WriteFiles_truncatesShorterContent(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("a-much-longer-certificate-payload"),
+	}))
+	makeWritableForRewrite(t, dataPath, "tls.crt")
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{
+		"tls.crt": []byte("short"),
+	}))
+
+	got, err := os.ReadFile(filepath.Join(dataPath, "tls.crt"))
+	require.NoError(t, err)
+	assert.Equal(t, "short", string(got), "trailing bytes of the previous write were not truncated")
+}
+
+// Identical content must not be rewritten: every write wakes the pod's watcher
+// (istio-agent reloads the certificate) for a no-op update, and camanager
+// rewrites all files on every trust-bundle change even when nothing differs.
+func Test_inplaceWriteStorage_WriteFiles_skipsIdenticalContent(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+	meta := metadata.Metadata{VolumeID: "vol-id"}
+
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{"tls.crt": []byte("same")}))
+
+	target := filepath.Join(dataPath, "tls.crt")
+	before, err := os.Stat(target)
+	require.NoError(t, err)
+
+	// Deliberately no makeWritableForRewrite: an identical write must return
+	// before even opening the file, so the 0440 mode never gets in the way.
+	time.Sleep(20 * time.Millisecond)
+	require.NoError(t, s.WriteFiles(meta, map[string][]byte{"tls.crt": []byte("same")}))
+
+	after, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime(),
+		"identical content was rewritten; the pod's watcher would be woken for a no-op reload")
+}
+
+// A half-torn-down atomic-writer layout (a `..data` chain whose timestamped
+// directory is gone) cannot be repaired by writing through it. The writer must
+// delegate to the inner atomic writer to rebuild the volume; watches on the old
+// inodes are already dead at that point, so this cannot break a live consumer.
+func Test_inplaceWriteStorage_WriteFiles_rebuildsBrokenSymlinkLayout(t *testing.T) {
+	s, dataPath := newTestInplaceStorage(t, "tls.crt")
+
+	// The `..data` chain exists, but the timestamped directory it points at
+	// does not.
+	require.NoError(t, os.Symlink("..2026_01_01_00_00_00.1", filepath.Join(dataPath, "..data")))
+	require.NoError(t, os.Symlink(filepath.Join("..data", "tls.crt"), filepath.Join(dataPath, "tls.crt")))
+
+	require.NoError(t, s.WriteFiles(metadata.Metadata{VolumeID: "vol-id"}, map[string][]byte{
+		"tls.crt": []byte("cert-new"),
+		"tls.key": []byte("key-new"),
+	}))
+
+	fake := s.inner.(*fakeInnerStore)
+	assert.Equal(t, 1, fake.writeFilesCalls,
+		"a broken symlink layout must be rebuilt by delegating to the inner atomic writer")
+
+	// Nothing must have been written in place around the broken chain.
+	_, err := os.Stat(filepath.Join(dataPath, "tls.key"))
+	assert.True(t, os.IsNotExist(err), "the in-place path must not run once the layout is known to be broken")
+}
+
+func Test_orderedWriteNames(t *testing.T) {
+	tests := map[string]struct {
+		files        []string
+		certFileName string
+		expOrder     []string
+	}{
+		"cert is written last": {
+			files:        []string{"tls.key", "tls.crt", "ca.crt", "service.jks"},
+			certFileName: "tls.crt",
+			expOrder:     []string{"ca.crt", "service.jks", "tls.key", "tls.crt"},
+		},
+		"cert only": {
+			files:        []string{"tls.crt"},
+			certFileName: "tls.crt",
+			expOrder:     []string{"tls.crt"},
+		},
+		"cert absent from the payload": {
+			files:        []string{"tls.key", "ca.crt"},
+			certFileName: "tls.crt",
+			expOrder:     []string{"ca.crt", "tls.key"},
+		},
+		"no files": {
+			files:        nil,
+			certFileName: "tls.crt",
+			expOrder:     []string{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			files := map[string][]byte{}
+			for _, file := range test.files {
+				files[file] = []byte(file)
+			}
+			assert.Equal(t, test.expOrder, orderedWriteNames(files, test.certFileName))
+		})
+	}
+}
+
+func Test_inplaceWriteStorage_fsGroupForMetadata(t *testing.T) {
+	const attrKey = "csi.cert-manager.athenz.io/fs-group"
+
+	tests := map[string]struct {
+		volumeContext    map[string]string
+		volumeMountGroup string
+		expFSGroup       *int64
+		expErr           bool
+	}{
+		"valid volume attribute": {
+			volumeContext: map[string]string{attrKey: "1234"},
+			expFSGroup:    ptrInt64(1234),
+		},
+		"attribute absent": {
+			volumeContext: map[string]string{"other": "1234"},
+			expFSGroup:    nil,
+		},
+		"attribute empty falls back to the volume mount group": {
+			volumeContext:    map[string]string{attrKey: ""},
+			volumeMountGroup: "4321",
+			expFSGroup:       ptrInt64(4321),
+		},
+		"not a number": {
+			volumeContext: map[string]string{attrKey: "not-a-gid"},
+			expErr:        true,
+		},
+		"zero is out of range": {
+			volumeContext: map[string]string{attrKey: "0"},
+			expErr:        true,
+		},
+		"above the maximum gid": {
+			volumeContext: map[string]string{attrKey: "4294967296"},
+			expErr:        true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := &inplaceWriteStorage{fsGroupVolumeAttributeKey: attrKey}
+
+			fsGroup, err := s.fsGroupForMetadata(metadata.Metadata{
+				VolumeContext:    test.volumeContext,
+				VolumeMountGroup: test.volumeMountGroup,
+			})
+			if test.expErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if test.expFSGroup == nil {
+				assert.Nil(t, fsGroup)
+				return
+			}
+			require.NotNil(t, fsGroup)
+			assert.Equal(t, *test.expFSGroup, *fsGroup)
+		})
+	}
+}
+
+func ptrInt64(i int64) *int64 { return &i }


### PR DESCRIPTION
## Problem

The csi-lib atomic writer replaces every file on certificate renewal: it stages the new content in a fresh timestamped directory, re-points the `..data` symlink, and deletes the previous directory.

Consumers that watch the certificate file with inotify (istio-agent being the prominent example, for gateways running with file-mounted certificates) bind their watch to the file's **inode**. The delete unlinks that inode, the kernel tears the watch down, and — since istio 1.29's symlink-aware watcher (istio/istio#57437) no longer re-arms in this layout — the pod silently keeps serving the previous certificate until it expires. We hit this in production: gateways froze on their first renewal and would have served an expired cert ~7 days later, with no error logged anywhere.

## Fix

New `--volume-write-mode` flag (also exposed as `app.driver.volumeWriteMode` in the Helm chart):

- `atomic-dir` (default): the upstream csi-lib behavior, unchanged for existing deployments. Note it silently breaks raw-inotify consumers as described above.
- `in-place` (opt-in): rewrite file **contents** through whatever symlink chain already exists (`WriteAt(0)` + `Truncate` + `Sync` on the same inode — no `O_TRUNC`, no rename, no unlink). A renewal reaches the pod as a plain `IN_MODIFY` event on the file it is already watching. Volumes previously written by the atomic writer keep their `..data` layout and are written through it, so existing pods pick up the new behavior without a restart.

Details:

- the certificate file is written last, so a watcher woken by the cert event always finds the matching key/CA/keystores already on disk
- the CA manager shares the driver's store; in in-place mode a trust-bundle update writes **only the CA file** — it does not read the current keypair and write that snapshot back, which could silently roll back a renewal that landed between the read and the write (and it can never recreate the atomic-writer layout behind a live pod's back)
- the payload is the complete desired file set, as it is upstream: files that stop being generated (e.g. keystores after disabling keystore support) are pruned instead of being served stale forever
- payload names are validated with the same rules as the upstream atomic writer (no absolute paths, no `..` elements, length limits) before anything touches the filesystem
- identical content is skipped (matches the atomic writer, avoids waking watchers for no-op rewrites); group ownership is still repaired if the volume's fsGroup changed
- a genuinely broken legacy layout (the `..data` chain itself dangling) falls back to the atomic writer to rebuild the volume; a single dangling file symlink under a healthy `..data` is repaired in place without touching the healthy siblings
- in atomic-dir mode the store is wrapped so that files created by a previous in-place deployment are cleared before each atomic write — without that, the atomic writer's `os.Readlink` probe hits `EINVAL` on a regular file, silently never creates the user-visible symlink, and the pod keeps reading stale data while `Write()` reports success. This makes switching back from `in-place` to `atomic-dir` safe on live volumes.

### Semantics and caveats

- **In-place rewrites are not atomic against concurrent readers.** Between the `WriteAt` and the `Truncate` a reader can observe new content followed by the tail of the old (the window is widest when the content shrinks). Both syscalls emit `IN_MODIFY`, so the last event a watcher receives always follows complete final content; a consumer that re-reads on every event (istio-agent does) converges. Full read atomicity is impossible without replacing the inode, which is the exact thing this mode exists to avoid.
- **Switching modes on a live volume** (`in-place` → `atomic-dir`) is supported: the wrapper clears in-place artifacts so atomic writes stay visible to the pod. The pod's inotify watches are destroyed by the first atomic write (inherent to a writer that replaces files); the data itself stays correct and visible.
- ⚠️ For deployments that have enabled `in-place`: **rolling back the image** to a release without this change (e.g. v0.0.15) is **not safe without re-publishing volumes**. The old atomic writer silently stops delivering renewals over the regular files in-place mode creates (`Write()` returns nil, the pod keeps the stale file until the cert expires — the same failure this PR fixes). Restart the affected pods (re-publish the volumes) after such a rollback. This should go in the release notes.

## Validation

- Unit tests cover: inode preservation across writes, write-through of a legacy `..data` layout, truncation of shorter content, write ordering, fsGroup parsing and ownership repair, payload-name validation, desired-state pruning (flat and legacy layouts), the narrowed broken-layout fallback (a dangling sibling under a healthy `..data` no longer rebuilds the volume), CA-only trust-bundle updates, and the atomic-dir wrapper clearing in-place artifacts (including nested payload names). Two tests run the real csi-lib atomic writer over the mode-switch paths.
- The camanager test flake (`Test_manageCAFiles`) was fixed along the way: the root-CA fake now signals when its subscription is live, the update func is installed before the run loop starts (this was a data race), and the deadline is no longer 500 ms.
- Live cluster: a volume created under v0.0.15 (atomic layout) was renewed by an in-place build **in place** — cert/key/keystore inodes unchanged, layout untouched, cert/key pair consistent — and istio ingress gateways logged `event for file certificate ... WRITE, pushing to proxy` with Envoy hot-reloading the renewed cert on every subsequent renewal.

## Notes for reviewers

- The default is `atomic-dir`, i.e. existing deployments keep the exact upstream write behavior until they opt in to `in-place`.
